### PR TITLE
Change trace log 'relative time' to be relative to start of trace

### DIFF
--- a/src/components/traces/details/logsTable.jsx
+++ b/src/components/traces/details/logsTable.jsx
@@ -30,7 +30,7 @@ function findLogEvent(logs, eventValue) {
     return _.find(logs, log => log.value.toLowerCase() === eventValue);
 }
 
-const LogsTable = ({logs}) => {
+const LogsTable = ({logs, startTime}) => {
     const flattenedLogs = logs.map(log => log.fields.map(field => ({
       timestamp: log.timestamp,
       key: field.key,
@@ -42,11 +42,6 @@ const LogsTable = ({logs}) => {
         const serverReceive = findLogEvent(flattenedLogs, 'sr');
         const serverSend = findLogEvent(flattenedLogs, 'ss');
         const clientReceive = findLogEvent(flattenedLogs, 'cr');
-
-        const startSpan = (clientSend || serverReceive || serverSend || clientReceive);
-        let startTime = 0;
-        if (startSpan) startTime = startSpan.timestamp;
-
         // display while making sure that logical ordering of events is maintained
         return (<table className="table table-striped">
             <thead>
@@ -74,7 +69,8 @@ const LogsTable = ({logs}) => {
 };
 
 LogsTable.propTypes = {
-    logs: PropTypes.object.isRequired
+    logs: PropTypes.object.isRequired,
+    startTime: PropTypes.number.isRequired
 };
 
 export default LogsTable;

--- a/src/components/traces/details/span.jsx
+++ b/src/components/traces/details/span.jsx
@@ -29,6 +29,7 @@ import serviceColor from '../../../utils/serviceColorMapper';
 export default class Span extends React.Component {
     static get propTypes() {
         return {
+            startTime: PropTypes.number.isRequired,
             index: PropTypes.number.isRequired,
             span: PropTypes.object.isRequired,
             totalDuration: PropTypes.number.isRequired,
@@ -215,6 +216,7 @@ export default class Span extends React.Component {
                     closeModal={this.closeModal}
                     serviceName={serviceName}
                     span={span}
+                    startTime={this.props.startTime}
                 />
                 <clipPath id="overflow">
                     <rect

--- a/src/components/traces/details/spanDetailsModal.jsx
+++ b/src/components/traces/details/spanDetailsModal.jsx
@@ -38,7 +38,7 @@ export default class SpanDetailsModal extends React.Component {
     tabViewer(span) {
         switch (this.state.tabSelected) {
             case 1:
-                return <LogsTable logs={span.logs} />;
+                return <LogsTable logs={span.logs} startTime={this.props.startTime} />;
             case 2:
                 return <TagsTable tags={span.tags} />;
             case 3:
@@ -86,5 +86,6 @@ SpanDetailsModal.propTypes = {
     isOpen: PropTypes.bool.isRequired,
     closeModal: PropTypes.func.isRequired,
     serviceName: PropTypes.string.isRequired,
-    span: PropTypes.object.isRequired
+    span: PropTypes.object.isRequired,
+    startTime: PropTypes.number.isRequired
 };


### PR DESCRIPTION
- Adjust the log section of a span modal so the timeframes are relative to the start of the trace, rather than the start of the span. 