### PR TITLE
Success graph fixes

### DIFF
--- a/src/components/trends/details/graphs/successGraph.jsx
+++ b/src/components/trends/details/graphs/successGraph.jsx
@@ -22,19 +22,26 @@ import options from './options';
 
 const backgroundColor = [['rgba(75, 192, 192, 0.2)']];
 const borderColor = [['rgba(75, 192, 192, 1)']];
+const successChartOptions = _.cloneDeep(options);
+successChartOptions.scales.yAxes = [{
+    display: true,
+    ticks: {
+        beginAtZero: true,
+        max: 100
+    }
+}];
 
 const SuccessGraph = ({successCount, failureCount}) => {
-    const data = [];
-    failureCount.map((failItem) => {
+    const data = _.flatMap(failureCount, ((failItem) => {
         const successItem = _.find(successCount, x => (x.timestamp === failItem.timestamp));
         if (successItem) {
-            data.push({
+            return {
                 x: new Date(failItem.timestamp),
                 y: (100 - ((failItem.value / (successItem.value + failItem.value)) * 100)).toFixed(3)
-            });
+            };
         }
         return null;
-    });
+    }));
     const chartData = {
         datasets: [{
             label: 'Success %',
@@ -45,18 +52,11 @@ const SuccessGraph = ({successCount, failureCount}) => {
         }],
         fill: 'end'
     };
-    const opt = _.cloneDeep(options);
-    opt.scales.yAxes = [{
-        display: true,
-        ticks: {
-            beginAtZero: true,
-            max: 100
-        }
-    }];
+
     return (<div className="col-md-12">
             <h5 className="text-center">Success %</h5>
             <div className="chart-container">
-                <Line data={chartData} options={opt} type="line" />
+                <Line data={chartData} options={successChartOptions} type="line" />
             </div>
         </div>
     );

--- a/src/components/trends/details/graphs/successGraph.jsx
+++ b/src/components/trends/details/graphs/successGraph.jsx
@@ -17,19 +17,24 @@
 import React from 'react';
 import {Line} from 'react-chartjs-2';
 import PropTypes from 'prop-types';
-
+import _ from 'lodash';
 import options from './options';
 
 const backgroundColor = [['rgba(75, 192, 192, 0.2)']];
 const borderColor = [['rgba(75, 192, 192, 1)']];
 
 const SuccessGraph = ({successCount, failureCount}) => {
-    // TODO make sure that success count and failure counts are merging on the right timestamps
-    const data = failureCount.map((items, index) => ({
-        x: new Date(items.timestamp),
-        y: (100 - ((items.value / (successCount[index].value + items.value)) * 100)).toFixed(3)
-    }));
-
+    const data = [];
+    failureCount.map((failItem) => {
+        const successItem = _.find(successCount, x => (x.timestamp === failItem.timestamp));
+        if (successItem) {
+            data.push({
+                x: new Date(failItem.timestamp),
+                y: (100 - ((failItem.value / (successItem.value + failItem.value)) * 100)).toFixed(3)
+            });
+        }
+        return null;
+    });
     const chartData = {
         datasets: [{
             label: 'Success %',
@@ -40,11 +45,18 @@ const SuccessGraph = ({successCount, failureCount}) => {
         }],
         fill: 'end'
     };
-
+    const opt = _.cloneDeep(options);
+    opt.scales.yAxes = [{
+        display: true,
+        ticks: {
+            beginAtZero: true,
+            max: 100
+        }
+    }];
     return (<div className="col-md-12">
             <h5 className="text-center">Success %</h5>
             <div className="chart-container">
-                <Line data={chartData} options={options} type="line" />
+                <Line data={chartData} options={opt} type="line" />
             </div>
         </div>
     );
@@ -55,4 +67,4 @@ SuccessGraph.propTypes = {
     failureCount: PropTypes.object.isRequired
 };
 
-export default SuccessGraph;
+export default SuccessGr

--- a/src/components/trends/details/graphs/successGraph.jsx
+++ b/src/components/trends/details/graphs/successGraph.jsx
@@ -67,4 +67,4 @@ SuccessGraph.propTypes = {
     failureCount: PropTypes.object.isRequired
 };
 
-export default SuccessGr
+export default SuccessGraph;


### PR DESCRIPTION
- Set graph scale from 0-100

- Only plot where the timestamps match up between failing data points and success data points