### PR TITLE
Small refactor to get rid of console warnings

### DIFF
--- a/src/components/common/withTracker.jsx
+++ b/src/components/common/withTracker.jsx
@@ -29,9 +29,8 @@ const trackPage = (page) => {
 
 const withTracker = (WrappedComponent) => {
     class Wrapper extends Component {
-
-        propTypes = {
-        location: PropTypes.objectOf(PropTypes.string)
+        static propTypes = {
+            location: PropTypes.objectOf(PropTypes.string).isRequired
         };
 
         componentDidMount() {

--- a/src/components/trends/details/trendDetailsToolbar.jsx
+++ b/src/components/trends/details/trendDetailsToolbar.jsx
@@ -64,8 +64,9 @@ export default class TrendHeaderToolbar extends React.Component {
             granularityDropdownOpen: false,
             showCustomTimeRangePicker: false
         };
-
-        this.fetchTrends(activeWindow, activeGranularity);
+    }
+    componentDidMount() {
+        this.fetchTrends(this.state.activeWindow, this.state.activeGranularity);
     }
     setWrapperRef(node) {
         this.wrapperRef = node;

--- a/src/components/trends/trendsHeader.jsx
+++ b/src/components/trends/trendsHeader.jsx
@@ -130,7 +130,7 @@ export default class TrendsHeader extends React.Component {
                 <div className="pull-right">
                     <span>Showing summary for </span>
                     <select className="trend-summary__time-range-selector" value={selectedIndex} onChange={this.handleTimeChange}>
-                        {options.map((window, index) => (<option value={index}>{window.isCustomTimeRange ? '' : 'last'} {window.longName}</option>))}
+                        {options.map((window, index) => (<option key={window.longName} value={index}>{window.isCustomTimeRange ? '' : 'last'} {window.longName}</option>))}
                     </select>
                 </div>
             </div>


### PR DESCRIPTION
Fetching trends needs to occur inside componentDidMount. If you do it in constructor method you trigger a nasty react warning in console. Same goes for non-static proptypes and iterations without keys 