### PR TITLE
allow log values to show up in the modal dialog

### DIFF
--- a/src/components/traces/details/timeline/logsTable.jsx
+++ b/src/components/traces/details/timeline/logsTable.jsx
@@ -51,7 +51,7 @@ const LogsTable = ({logs, startTime}) => {
             {flattenedLogs.map(log =>
                 (<tr>
                     <td>{log.key}</td>
-                    <td>{LogEnum[log.value]||log.value}</td>
+                    <td>{LogEnum[log.value] || log.value}</td>
                     <td>{formatters.toDurationString(log.timestamp - startTime)}</td>
                     <td>{formatters.toTimestringWithMs(log.timestamp)}</td>
                 </tr>)

--- a/src/components/traces/details/timeline/logsTable.jsx
+++ b/src/components/traces/details/timeline/logsTable.jsx
@@ -51,7 +51,7 @@ const LogsTable = ({logs, startTime}) => {
             {flattenedLogs.map(log =>
                 (<tr>
                     <td>{log.key}</td>
-                    <td>{LogEnum[log.value]}</td>
+                    <td>{LogEnum[log.value]||log.value}</td>
                     <td>{formatters.toDurationString(log.timestamp - startTime)}</td>
                     <td>{formatters.toTimestringWithMs(log.timestamp)}</td>
                 </tr>)


### PR DESCRIPTION
This fix allows users to use the log api to capture events and the values still show up. Values were being blanked due to the fact that only standard tags were in the enum.