### PR TITLE
operationName autosuggest and whitespace changes

### DIFF
--- a/src/components/universalSearch/searchBar/autosuggest.jsx
+++ b/src/components/universalSearch/searchBar/autosuggest.jsx
@@ -61,6 +61,13 @@ export default class Autocomplete extends React.Component {
         if (children.length) children[children.length - 1].focus();
     }
 
+    static completeInputString(inputString) {
+        if (inputString[0] === '(') {
+            return inputString[inputString.length - 1] === ')';
+        }
+        return /^([a-zA-Z0-9\s-]+)[=]([a-zA-Z0-9,\s-]+)$/g.test(inputString);
+    }
+
     constructor(props) {
         super(props);
 
@@ -127,7 +134,7 @@ export default class Autocomplete extends React.Component {
     // Takes current active word and searches suggestion options for keys that are valid.
     setSuggestions(input) {
         const suggestionArray = [];
-        const splitInput = input.replace('(', '').split(',');
+        const splitInput = input.replace(/\s*=\s*/g, '=').replace('(', '').split(' ');
         const targetInput = splitInput[splitInput.length - 1];
 
         const equalSplitter = targetInput.indexOf('=');
@@ -135,8 +142,8 @@ export default class Autocomplete extends React.Component {
         let type;
         if (equalSplitter > 0) {
             type = 'Values';
-            const key = targetInput.substring(0, equalSplitter);
-            value = targetInput.substring(equalSplitter + 1, targetInput.length);
+            const key = targetInput.substring(0, equalSplitter).trim();
+            value = targetInput.substring(equalSplitter + 1, targetInput.length).trim();
             if (this.props.options[key]) {
                 this.props.options[key].forEach((option) => {
                     if (option.toLowerCase().includes(value.toLowerCase())) {
@@ -204,7 +211,7 @@ export default class Autocomplete extends React.Component {
 
     // Selection choice fill when navigating with arrow keys
     handleSelectionFill() {
-        const splitInput = this.inputRef.value.split(',');
+        const splitInput = this.inputRef.value.replace(/\s*=\s*/g, '=').split(' ');
         const targetInput = splitInput[splitInput.length - 1];
         const isNested = targetInput[0] === '(' ? '(' : '';
         const equalSplitter = targetInput.indexOf('=');
@@ -217,7 +224,7 @@ export default class Autocomplete extends React.Component {
             fillValue = `${isNested}${this.state.suggestionStrings[this.state.suggestionIndex || 0]}`;
         }
         splitInput[splitInput.length - 1] = fillValue;
-        this.inputRef.value = splitInput.join(',');
+        this.inputRef.value = splitInput.join(' ');
     }
 
     // Selection chose when clicking or pressing space/tab/enter
@@ -225,7 +232,7 @@ export default class Autocomplete extends React.Component {
         this.handleSelectionFill();
         this.handleBlur();
         this.inputRef.focus();
-        const splitInput = this.inputRef.value.split(',');
+        const splitInput = this.inputRef.value.replace(/\s*=\s*/g, '=').split(' ');
         const targetInput = splitInput[splitInput.length - 1];
         if (targetInput.indexOf('=') < 0) {
             this.inputRef.value = `${this.inputRef.value}=`;
@@ -244,7 +251,7 @@ export default class Autocomplete extends React.Component {
             e.preventDefault();
             this.handleSelection();
             this.handleBlur();
-        } else if (keyPressed === ENTER || ((keyPressed === TAB || keyPressed === SPACE) && e.target.value)) {
+        } else if (keyPressed === ENTER || (keyPressed === TAB && e.target.value) || (keyPressed === SPACE && Autocomplete.completeInputString(this.inputRef.value))) {
             e.preventDefault();
             this.updateChips();
         } else if (keyPressed === UP) {
@@ -274,7 +281,7 @@ export default class Autocomplete extends React.Component {
                 if (key === nestedKeys[nestedKeys.length - 1]) {
                     fullString += `${key}=${chipValue[key]}`;
                 } else {
-                    fullString += `${key}=${chipValue[key]},`;
+                    fullString += `${key}=${chipValue[key]} `;
                 }
             });
             this.inputRef.value = `(${fullString.trim()})`;
@@ -337,7 +344,7 @@ export default class Autocomplete extends React.Component {
     // Test for correct formatting on K/V pairs
     testForValidInputString(kvPair) {
         if (/^([a-zA-Z0-9\s-]+)[=]([a-zA-Z0-9,\s-]+)$/g.test(kvPair)) { // Ensure format is a=b
-            const valueKey = kvPair.substring(0, kvPair.indexOf('='));
+            const valueKey = kvPair.substring(0, kvPair.indexOf('=')).trim();
             if (Object.keys(this.props.options).includes(valueKey)) { // Ensure key is searchable
                 this.setState(prevState => ({existingKeys: [...prevState.existingKeys, valueKey]}));
                 return true;
@@ -348,7 +355,7 @@ export default class Autocomplete extends React.Component {
             return false;
         }
         this.setState({
-            inputError: 'Invalid K/V Pair, please use format "abc=xyz" or "(abc=def,ghi=jkl)"'
+            inputError: 'Invalid K/V Pair, please use format "abc=xyz" or "(abc=def ghi=jkl)"'
         });
         return false;
     }
@@ -356,7 +363,7 @@ export default class Autocomplete extends React.Component {
     // Adds inputted text chip to client side store
     updateChips() {
         this.handleBlur();
-        const inputValue = this.inputRef.value;
+        const inputValue = this.inputRef.value.trim().replace(/\s*=\s*/g, '=');
         if (!inputValue) return;
         let formattedValue = null;
         if (inputValue.indexOf('(') > -1) {
@@ -366,11 +373,11 @@ export default class Autocomplete extends React.Component {
                 });
                 return;
             }
-            formattedValue = inputValue.substring(1, inputValue.length - 1);
+            formattedValue = inputValue.substring(1, inputValue.length - 1).trim();
         } else {
             formattedValue = inputValue;
         }
-        const splitInput = formattedValue.split(',');
+        const splitInput = formattedValue.split(' ');
         if (splitInput.every(this.testForValidInputString)) { // Valid input tests
             let chipKey = null;
             let chipValue = null;
@@ -380,13 +387,14 @@ export default class Autocomplete extends React.Component {
                 chipKey = `nested_${chipIndex}`;
                 chipValue = {};
                 splitInput.forEach((kvPair) => {
-                    const key = kvPair.substring(0, kvPair.indexOf('='));
-                    chipValue[key] = kvPair.substring(kvPair.indexOf('=') + 1, kvPair.length);
+                    const trimmedPair = kvPair.trim();
+                    const key = trimmedPair.substring(0, kvPair.indexOf('='));
+                    chipValue[key] = trimmedPair.substring(kvPair.indexOf('=') + 1, kvPair.length);
                 });
             } else {
                 const kvPair = splitInput[0];
-                chipKey = kvPair.substring(0, kvPair.indexOf('='));
-                chipValue = kvPair.substring(kvPair.indexOf('=') + 1, kvPair.length);
+                chipKey = kvPair.substring(0, kvPair.indexOf('=')).trim();
+                chipValue = kvPair.substring(kvPair.indexOf('=') + 1, kvPair.length).trim();
             }
             this.props.uiState.chips[chipKey] = chipValue;
             if (chipKey.includes('serviceName')) {

--- a/src/components/universalSearch/searchBar/suggestions.jsx
+++ b/src/components/universalSearch/searchBar/suggestions.jsx
@@ -20,7 +20,7 @@ import PropTypes from 'prop-types';
 export default class Suggestions extends React.Component {
     static propTypes = {
         suggestionStrings: PropTypes.array.isRequired,
-        suggestedOnType: PropTypes.string.isRequired,
+        suggestedOnType: PropTypes.string,
         suggestedOnValue: PropTypes.string,
         suggestionIndex: PropTypes.number,
         handleHover: PropTypes.func.isRequired,

--- a/src/stores/operationStore.js
+++ b/src/stores/operationStore.js
@@ -22,7 +22,7 @@ import { ErrorHandlingStore } from './errorHandlingStore';
 export class OperationStore extends ErrorHandlingStore {
     @observable operations = [];
 
-    @action fetchOperations(serviceName) {
+    @action fetchOperations(serviceName, callback) {
         this.operations = [];
         axios({
             method: 'get',
@@ -30,6 +30,7 @@ export class OperationStore extends ErrorHandlingStore {
             })
             .then((response) => {
                 this.operations = ['all', ...response.data.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))];
+                callback();
             })
             .catch((result) => {
                 OperationStore.handleError(result);


### PR DESCRIPTION
- populate operationName autosuggest value upon a successful serviceName chip addition
- allow whitespace between equals in KV pairs, still triggers autosuggest
- separate kv pairs in nested groups with whitespace rather than ","