### PR TITLE
Updated PropTypes to reduce development warnings

### DIFF
--- a/src/components/traces/searchBar/pickers/fieldsPicker.jsx
+++ b/src/components/traces/searchBar/pickers/fieldsPicker.jsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import {observer} from 'mobx-react';
+import {observer, PropTypes as MobxPropTypes} from 'mobx-react';
 import PropTypes from 'prop-types';
 
 import Autocomplete from '../../utils/autocomplete';
@@ -24,7 +24,7 @@ import Autocomplete from '../../utils/autocomplete';
 export default class TimeWindowPicker extends React.Component {
     static propTypes = {
         uiState: PropTypes.object.isRequired,
-        options: PropTypes.array.isRequired
+        options: MobxPropTypes.observableArray // eslint-disable-line react/require-default-props
     };
 
     render() {

--- a/src/components/traces/searchBar/searchQueryBar.jsx
+++ b/src/components/traces/searchBar/searchQueryBar.jsx
@@ -33,7 +33,7 @@ export default class SearchQueryBar extends React.Component {
         serviceStore: PropTypes.object.isRequired,
         operationStore: PropTypes.object.isRequired,
         searchCallback: PropTypes.func.isRequired,
-        searchableKeysStore: PropTypes.array.isRequired
+        searchableKeysStore: PropTypes.object.isRequired
     };
 
     constructor(props) {

--- a/src/components/traces/utils/autocomplete.jsx
+++ b/src/components/traces/utils/autocomplete.jsx
@@ -17,14 +17,14 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {observer} from 'mobx-react';
+import {observer, PropTypes as MobxPropTypes} from 'mobx-react';
 
 
 @observer
 export default class Autocomplete extends React.Component {
     static propTypes = {
         uiState: PropTypes.object.isRequired,
-        options: PropTypes.array
+        options: MobxPropTypes.observableArray
     };
 
     static defaultProps = {


### PR DESCRIPTION
I'm a developer at HomeAway.com and I am currently working on Haystack UI for a project. Because of the warnings my browser was throwing, I noticed that the PropTypes for searchableKeysStore was incorrect and updated it.

Also, I noticed that in two places, the expected prop type was an array. However, since the actual inherited prop was an observable array, the browser threw a warning because it interpreted it as an object. Therefore, I updated those two places using mobx's in house prop types.