### PR TITLE
Made asset watching available in start:dev script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3637,6 +3637,88 @@
         "typedarray": "^0.0.6"
       }
     },
+    "concurrently": {
+      "version": "3.6.0",
+      "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/concurrently/-/concurrently-3.6.0.tgz",
+      "integrity": "sha1-wl40sVap1b1PJWoNhfYZJDiuSB8=",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "commander": "2.6.0",
+        "date-fns": "^1.23.0",
+        "lodash": "^4.5.1",
+        "read-pkg": "^3.0.0",
+        "rx": "2.3.24",
+        "spawn-command": "^0.0.2-1",
+        "supports-color": "^3.2.3",
+        "tree-kill": "^1.1.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.6.0",
+          "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/commander/-/commander-2.6.0.tgz",
+          "integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
+      }
+    },
     "configstore": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
@@ -4332,6 +4414,12 @@
         "whatwg-mimetype": "^2.0.0",
         "whatwg-url": "^6.4.0"
       }
+    },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha1-EuYJzcuTUScxHQTTMzTilgoqVOY=",
+      "dev": true
     },
     "date-now": {
       "version": "0.1.4",
@@ -5686,7 +5774,7 @@
     },
     "fill-keys": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/fill-keys/-/fill-keys-1.0.2.tgz",
       "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
       "dev": true,
       "requires": {
@@ -8550,6 +8638,12 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hoek": {
+      "version": "4.2.1",
+      "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs=",
+      "dev": true
+    },
     "hoist-non-react-statics": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
@@ -9123,7 +9217,7 @@
     },
     "is-object": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/is-object/-/is-object-1.0.1.tgz",
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
       "dev": true
     },
@@ -9292,6 +9386,12 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
+    "isemail": {
+      "version": "2.2.1",
+      "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/isemail/-/isemail-2.2.1.tgz",
+      "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -9322,6 +9422,25 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "items": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/items/-/items-2.1.1.tgz",
+      "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg=",
+      "dev": true
+    },
+    "joi": {
+      "version": "9.2.0",
+      "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/joi/-/joi-9.2.0.tgz",
+      "integrity": "sha1-M4WseQGSEwy+Iw6ALsAskhW7/to=",
+      "dev": true,
+      "requires": {
+        "hoek": "4.x.x",
+        "isemail": "2.x.x",
+        "items": "2.x.x",
+        "moment": "2.x.x",
+        "topo": "2.x.x"
+      }
     },
     "js-base64": {
       "version": "2.4.3",
@@ -10452,7 +10571,7 @@
     },
     "module-not-found-error": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
       "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
       "dev": true
     },
@@ -16719,6 +16838,12 @@
         "aproba": "^1.1.1"
       }
     },
+    "rx": {
+      "version": "2.3.24",
+      "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/rx/-/rx-2.3.24.tgz",
+      "integrity": "sha1-FPlQpCF9fjXapxu8vljv9o6ksrc=",
+      "dev": true
+    },
     "rx-lite": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
@@ -17151,6 +17276,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "spawn-command": {
+      "version": "0.0.2-1",
+      "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/spawn-command/-/spawn-command-0.0.2-1.tgz",
+      "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
       "dev": true
     },
     "spdx-correct": {
@@ -17704,6 +17835,15 @@
       "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-0.0.1.tgz",
       "integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo="
     },
+    "topo": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/topo/-/topo-2.0.2.tgz",
+      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+      "dev": true,
+      "requires": {
+        "hoek": "4.x.x"
+      }
+    },
     "touch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
@@ -17738,6 +17878,12 @@
           "dev": true
         }
       }
+    },
+    "tree-kill": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/tree-kill/-/tree-kill-1.2.0.tgz",
+      "integrity": "sha1-WEZ4Yje0I5AU8F2xVrZDIS1MbzY=",
+      "dev": true
     },
     "trim-newlines": {
       "version": "2.0.0",
@@ -18324,6 +18470,33 @@
       "dev": true,
       "requires": {
         "browser-process-hrtime": "^0.1.2"
+      }
+    },
+    "wait-on": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/wait-on/-/wait-on-2.1.0.tgz",
+      "integrity": "sha1-PErOH1cmbKW+f6JeDBWAO4icpGo=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.1",
+        "joi": "^9.2.0",
+        "minimist": "^1.2.0",
+        "request": "^2.78.0",
+        "rx": "^4.1.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "rx": {
+          "version": "4.1.0",
+          "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/rx/-/rx-4.1.0.tgz",
+          "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
+          "dev": true
+        }
       }
     },
     "warning": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "npm run eslint && mocha --require ignore-styles --compilers js:babel-register --require ./test/src/test_helper.js \"test/**/*@(.js|.jsx)\" --exit --timeout 10000",
     "build": "npm run clean && npm run codegen && npm run coverage && webpack --mode=production",
     "start": "node server/start.js",
-    "start:dev": "npm run clean && npm run codegen && npm run test && NODE_ENV=development webpack --mode=development && NODE_ENV=development nodemon --ignore 'public/*' server/start.js",
+    "start:dev": "npm run clean && npm run codegen && npm run test && concurrently -r \"npm run watch\" \"wait-on public/bundles/report.html && npm run start:devserver\"",
+    "start:devserver": "NODE_ENV=development nodemon --ignore 'public/*' server/start.js",
     "watch": "NODE_ENV=development webpack -w --mode=development"
   },
   "engines": {
@@ -61,6 +62,7 @@
     "chai": "^4.1.2",
     "chalk": "^2.4.1",
     "chart.js": "^2.7.2",
+    "concurrently": "^3.6.0",
     "coveralls": "^3.0.1",
     "css-loader": "^0.28.11",
     "enzyme": "^3.3.0",
@@ -114,6 +116,7 @@
     "vis": "^4.21.0",
     "vizceral": "^4.6.3",
     "vizceral-react": "^4.5.5",
+    "wait-on": "^2.1.0",
     "webpack": "^4.16.1",
     "webpack-bundle-analyzer": "^2.11.3",
     "webpack-command": "^0.4.1"


### PR DESCRIPTION
HomeAway developer here. So in the past few weeks, I've been working on the react side this project. One thing that really frustrated me was that the assets would not rebuild when I changed a file in the `src` directory during `start:dev`, even though sometimes the server would restart when I changed a javascript file. Today, I decided to go into the `webpack.config.js` and `package.json` to try to enable hot reloading and this is when I realized that there was a `watch` script that I needed run in a whole new shell for this to work. I wanted to make this process simpler and more intuitive.

In this PR, I changed the `start:dev` script such that it uses `concurrently` to run the webpack hot-reloading/watching in parallel with the `nodemon` server side hot-reloading. It works by building the webpack builds the project and then, when the build finishes (the report.html file is made), it runs nodemon server in parallel.

This way, developers who don't read the documentation carefully (like me) can get client and server side reloading out of the box. There is no need for an extra shell nor an entire rebuild for asset reloading.

Of course, these changes require that some sections of the `README.md` be updated. I decided not to make those changes as I believe you folks would have more appropriate wording for it.

Let me know what you think!