### PR TITLE
Updated Related Traces Feature to be solely universal

### DIFF
--- a/src/components/traces/details/relatedTraces/relatedTracesRow.jsx
+++ b/src/components/traces/details/relatedTraces/relatedTracesRow.jsx
@@ -31,26 +31,17 @@ export default class RelatedTracesRow extends React.Component {
         startTime: PropTypes.number.isRequired,
         rootError: PropTypes.bool.isRequired,
         services: MobxPropTypes.observableArray,
-        duration: PropTypes.number.isRequired,
-        isUniversalSearch: PropTypes.bool.isRequired
+        duration: PropTypes.number.isRequired
     };
 
     static defaultProps = {
         services: []
     };
 
-    static openTrendDetailInNewTab(traceId, serviceName, operationName, isUniversalSearch) {
+    static openTrendDetailInNewTab(traceId) {
         let traceUrl = '';
-        if (isUniversalSearch) {
-            const search = {traceId}; // TODO add specific time for trace
-            traceUrl = linkBuilder.withAbsoluteUrl(linkBuilder.universalSearchTracesLink(search));
-        } else {
-            traceUrl = linkBuilder.withAbsoluteUrl(linkBuilder.createTracesLink({
-                serviceName,
-                operationName,
-                traceId
-            }));
-        }
+        const search = {traceId};
+        traceUrl = linkBuilder.withAbsoluteUrl(linkBuilder.universalSearchTracesLink(search));
 
         const tab = window.open(traceUrl, '_blank');
         tab.focus();
@@ -98,10 +89,10 @@ export default class RelatedTracesRow extends React.Component {
     }
 
     render() {
-        const {traceId, serviceName, operationName, spanCount, services, startTime, rootError, duration, isUniversalSearch} = this.props;
+        const {traceId, serviceName, operationName, spanCount, services, startTime, rootError, duration} = this.props;
 
         return (
-            <tr onClick={() => RelatedTracesRow.openTrendDetailInNewTab(traceId, serviceName, operationName, isUniversalSearch)}>
+            <tr onClick={() => RelatedTracesRow.openTrendDetailInNewTab(traceId)}>
                 <td className="trace-trend-table_cell">
                     {RelatedTracesRow.timeColumnFormatter(startTime)}
                 </td>

--- a/src/components/traces/details/relatedTraces/relatedTracesTab.jsx
+++ b/src/components/traces/details/relatedTraces/relatedTracesTab.jsx
@@ -24,8 +24,7 @@ import linkBuilder from '../../../../utils/linkBuilder';
 export default class relatedTracesTab extends React.Component {
     static propTypes = {
         searchQuery: PropTypes.object.isRequired,
-        relatedTraces: MobxPropTypes.observableArray,
-        isUniversalSearch: PropTypes.bool.isRequired
+        relatedTraces: MobxPropTypes.observableArray
     };
 
     static defaultProps = {
@@ -50,7 +49,7 @@ export default class relatedTracesTab extends React.Component {
     }
 
     render() {
-        const {relatedTraces, isUniversalSearch} = this.props;
+        const {relatedTraces} = this.props;
         const {numDisplayedTraces} = this.state;
 
         const relatedTracesList = relatedTraces.slice(0, numDisplayedTraces);
@@ -73,7 +72,6 @@ export default class relatedTracesTab extends React.Component {
                             <RelatedTracesRow
                                 key={relatedTrace.traceId}
                                 {...relatedTrace}
-                                isUniversalSearch={isUniversalSearch}
                             />
                         ))
                     }

--- a/src/components/traces/details/relatedTraces/relatedTracesTabContainer.jsx
+++ b/src/components/traces/details/relatedTraces/relatedTracesTabContainer.jsx
@@ -27,8 +27,7 @@ import { toPresetDisplayText } from '../../utils/presets';
 export default class RelatedTracesTabContainer extends React.Component {
     static propTypes = {
         traceId: PropTypes.string.isRequired, // eslint-disable-line react/no-unused-prop-types
-        store: PropTypes.object.isRequired,
-        isUniversalSearch: PropTypes.bool.isRequired
+        store: PropTypes.object.isRequired
     };
 
     static timePresetOptions = (window.haystackUiConfig && window.haystackUiConfig.tracesTimePresetOptions);
@@ -104,13 +103,13 @@ export default class RelatedTracesTabContainer extends React.Component {
     }
 
     render() {
-        const { store, isUniversalSearch } = this.props;
+        const { store } = this.props;
         const { selectedTimeIndex, selectedFieldIndex} = this.state;
 
         return (
             <section>
                 <div className="text-left">
-                    <span>Relate Traces by: </span>
+                    <span>Find Related Traces by: </span>
                     <select id="field" className="time-range-selector" value={selectedFieldIndex || ''} onChange={this.handleFieldChange}>
                             {!selectedFieldIndex ? <option key="empty" value="" /> : null}
                             {RelatedTracesTabContainer.fieldOptions.map((fieldOp, index) => (
@@ -132,7 +131,7 @@ export default class RelatedTracesTabContainer extends React.Component {
                         pending: () => <Loading />,
                         rejected: reason => <Error errorMessage={reason}/>,
                         fulfilled: () => ((store.relatedTraces && store.relatedTraces.length)
-                                ? <RelatedTracesTab searchQuery={store.searchQuery} relatedTraces={store.relatedTraces} isUniversalSearch={isUniversalSearch}/>
+                                ? <RelatedTracesTab searchQuery={store.searchQuery} relatedTraces={store.relatedTraces}/>
                                 : <Error errorMessage="No related traces found"/>)
                     })
                 }

--- a/src/components/traces/details/traceDetails.jsx
+++ b/src/components/traces/details/traceDetails.jsx
@@ -47,7 +47,7 @@ export default class TraceDetails extends React.Component {
             case 3:
                 return <TrendsTabContainer traceId={traceId} store={traceDetailsStore} isUniversalSearch={isUniversalSearch}/>;
             case 4:
-                return <RelatedTracesTabContainer traceId={traceId} store={traceDetailsStore} isUniversalSearch={isUniversalSearch}/>;
+                return <RelatedTracesTabContainer traceId={traceId} store={traceDetailsStore}/>;
             default:
                 return <TimelineTabContainer traceId={traceId} store={traceDetailsStore} />;
         }

--- a/test/src/components/traces/traces.spec.jsx
+++ b/test/src/components/traces/traces.spec.jsx
@@ -310,7 +310,7 @@ function TraceDetailsStubComponent({traceDetailsStore, traceId, location, baseSe
 }
 
 function RelatedTracesContainerStub({traceId, store}) {
-    return (<RelatedTracesTabContainer traceId={traceId} store={store} isUniversalSearch={false} />);
+    return (<RelatedTracesTabContainer traceId={traceId} store={store} />);
 }
 
 function handleExpectedRejections(reason) {
@@ -704,7 +704,7 @@ describe('<Traces />', () => {
                 const absStub = sinon.stub(linkBuilder, 'withAbsoluteUrl').returns('string');
                 const uniStub = sinon.stub(linkBuilder, 'universalSearchTracesLink').returns('string');
 
-                const wrapper = mount(<RelatedTracesTab searchQuery={{}} relatedTraces={observable.array(stubResults)} isUniversalSearch={false} />);
+                const wrapper = mount(<RelatedTracesTab searchQuery={{}} relatedTraces={observable.array(stubResults)} />);
                 // Click showMoreTraces button
                 wrapper.find('a.btn-default').simulate('click');
 
@@ -717,28 +717,6 @@ describe('<Traces />', () => {
                 delete global.window.open;
             });
 
-            it('should have a well formed related trace that opens in a new tab, non universal', () => {
-                // mocking window.open and the window object with focus method it returns
-                const focusStub = sinon.stub();
-                global.window.open = () => ({ focus: focusStub });
-
-                const absStub = sinon.stub(linkBuilder, 'withAbsoluteUrl').returns('string');
-                const creStub = sinon.stub(linkBuilder, 'createTracesLink').returns('string');
-
-                const wrapper = mount(<table><tbody><RelatedTracesRow key={stubResults[0].traceId} {...stubResults[0]} isUniversalSearch={false}/></tbody></table>);
-                expect(wrapper.find('.trace-trend-table_cell')).to.have.length(5);
-
-                wrapper.find('tr').simulate('click');
-
-                expect(absStub.calledOnce).to.equal(true);
-                expect(creStub.calledOnce).to.equal(true);
-                expect(focusStub.calledOnce).to.equal(true);
-
-                linkBuilder.withAbsoluteUrl.restore();
-                linkBuilder.createTracesLink.restore();
-                delete global.window.open;
-            });
-
             it('should have a related trace that opens in a new tab, universal', () => {
                 // mocking window.open and the window object with focus method it returns
                 const focusStub = sinon.stub();
@@ -747,7 +725,7 @@ describe('<Traces />', () => {
                 const absStub = sinon.stub(linkBuilder, 'withAbsoluteUrl').returns('string');
                 const uniStub = sinon.stub(linkBuilder, 'universalSearchTracesLink').returns('string');
 
-                const wrapper = mount(<table><tbody><RelatedTracesRow key={stubResults[0].traceId} {...stubResults[0]} isUniversalSearch /></tbody></table>);
+                const wrapper = mount(<table><tbody><RelatedTracesRow key={stubResults[0].traceId} {...stubResults[0]} /></tbody></table>);
                 expect(wrapper.find('.trace-trend-table_cell')).to.have.length(5);
 
                 wrapper.find('tr').simulate('click');


### PR DESCRIPTION
From my conversation with @vsen , I learned that Haystack UI is heading towards being solely universal. Therefore, I have removed the logic from the relatedTraces feature that switches between the normal view and universal view, thus going only to universal. I hope this better prepares this feature for the future.