### PR TITLE
Spikes conversion of UI towards zipkin v2 read endpoints

### DIFF
--- a/server/config/base.js
+++ b/server/config/base.js
@@ -38,7 +38,7 @@ module.exports = {
             //  - haystack - gets data from haystack query service
             //  - zipkin - bridge for using an existing zipkin api,
             //             zipkin connector expects a zipkin config field specifying zipkin api url,
-            //             eg. zipkinUrl: 'http://<zipkin>/api/v1'}
+            //             eg. zipkinUrl: 'http://<zipkin>/api/v2'}
             //  - stub - a stub used during development, will be removed in future
             connectorName: 'stub'
         },

--- a/server/connectors/traces/zipkin/converter.js
+++ b/server/connectors/traces/zipkin/converter.js
@@ -15,6 +15,8 @@
  */
 const searchResultsTransformer = require('../haystack/search/searchResultsTransformer');
 
+// NOTICE: This converter was originally ported from the following ASL 2.0 code:
+// https://github.com/openzipkin/zipkin/blob/6fbef6bcfc84e721215c1037771300643eb1b0ed/zipkin-ui/js/spanConverter.js
 function toHaystackLog(annotation) {
   return {
     timestamp: annotation.timestamp,
@@ -135,16 +137,20 @@ function toHaystackSpan(span) {
     }
   });
 
+  let remoteAddressTag;
   switch (kind) {
     case 'CLIENT':
+      remoteAddressTag = 'server.service_name';
       begin = 'cs';
       end = 'cr';
       break;
     case 'SERVER':
+      remoteAddressTag = 'client.service_name';
       begin = 'sr';
       end = 'ss';
       break;
     case 'PRODUCER':
+      remoteAddressTag = 'broker.service_name';
       begin = 'ms';
       end = 'ws';
       if (startTs === 0 || (msTs !== 0 && msTs < startTs)) {
@@ -155,6 +161,7 @@ function toHaystackSpan(span) {
       }
       break;
     case 'CONSUMER':
+      remoteAddressTag = 'broker.service_name';
       if (startTs === 0 || (wrTs !== 0 && wrTs < startTs)) {
         startTs = wrTs;
       }
@@ -208,11 +215,12 @@ function toHaystackSpan(span) {
     convertSuccessTag(res.tags);
     convertMethodUriTag(res.tags);
   }
+
   if (span.remoteEndpoint) {
     const remoteService = sanitizeName(span.remoteEndpoint.serviceName);
     if (remoteService !== 'not_found') {
       res.tags.push({
-        key: 'remote.service_name',
+        key: remoteAddressTag || 'remote.service_name',
         value: remoteService
       });
     }
@@ -220,13 +228,216 @@ function toHaystackSpan(span) {
 
   return res;
 }
+/*
+ * Instrumentation should set span.startTime when recording a span so that guess-work
+ * isn't needed. Since a lot of instrumentation don't, we have to make some guesses.
+ *
+ * * If there is a 'cs', use that
+ * * Fall back to 'sr'
+ * * Otherwise, return undefined
+ */
+// originally zipkin.internal.ApplyTimestampAndDuration.guessTimestamp
+function guessTimestamp(span) {
+  if (span.startTime || span.logs.length === 0) {
+    return span.startTime;
+  }
+  let rootServerRecv;
+  for (let i = 0; i < span.logs.length; i += 1) {
+    const a = span.logs[i];
+    if (a.fields[0].value === 'cs') {
+      return a.timestamp;
+    } else if (a.fields[0].value === 'sr') {
+      rootServerRecv = a.timestamp;
+    }
+  }
+  return rootServerRecv;
+}
+
+/*
+ * For RPC two-way spans, the duration between 'cs' and 'cr' is authoritative. RPC one-way spans
+ * lack a response, so the duration is between 'cs' and 'sr'. We special-case this to avoid
+ * setting incorrect duration when there's skew between the client and the server.
+ */
+// originally zipkin.internal.ApplyTimestampAndDuration.apply
+function applyTimestampAndDuration(span) {
+  const logsLength = span.logs.length;
+  // Don't overwrite authoritatively set startTime and duration!
+  if ((span.startTime && span.duration) || logsLength === 0) {
+    return span;
+  }
+
+  // We cannot backfill duration on a span with less than two logs. However, we
+  // can backfill timestamp.
+  if (logsLength < 2) {
+    if (span.startTime) return span;
+    const guess = guessTimestamp(span);
+    if (!guess) return span;
+    span.startTime = guess; // eslint-disable-line no-param-reassign
+    return span;
+  }
+
+  // Prefer RPC one-way (cs -> sr) vs arbitrary annotations.
+  let first = span.logs[0].timestamp;
+  let last = span.logs[logsLength - 1].timestamp;
+  span.logs.forEach((a) => {
+    if (a.fields[0].value === 'cs') {
+      first = a.timestamp;
+    } else if (a.fields[0].value === 'cr') {
+      last = a.timestamp;
+    }
+  });
+
+  if (!span.startTime) {
+    span.startTime = first; // eslint-disable-line no-param-reassign
+  }
+  if (!span.duration && last !== first) {
+    span.duration = last - first; // eslint-disable-line no-param-reassign
+  }
+  return span;
+}
+
+// This guards to ensure we don't add duplicate logs on merge
+function maybePushHaystackLog(annotations, a) {
+  if (annotations.findIndex(b => a.fields[0].value === b.fields[0].value) === -1) {
+    annotations.push(a);
+  }
+}
+
+// This guards to ensure we don't add duplicate tags on merge
+function maybePushHaystackTag(tags, a) {
+  if (tags.findIndex(b => a.key === b.key) === -1) {
+    tags.push(a);
+  }
+}
+
+function merge(left, right) {
+  const res = {
+    traceId: right.traceId.length > 16 ? right.traceId : left.traceId
+  };
+
+  if (left.parentSpanId) {
+    res.parentSpanId = left.parentSpanId;
+  } else if (right.parentSpanId) {
+    res.parentSpanId = right.parentSpanId;
+  }
+
+  res.spanId = left.spanId;
+
+  // When we move to span model 2, remove this code in favor of using Span.kind == CLIENT
+  let leftClientSpan;
+  let rightClientSpan;
+  let rightServerSpan;
+
+  const logs = [];
+
+  (left.logs || []).forEach((a) => {
+    if (a.fields[0].value === 'cs') leftClientSpan = true;
+    maybePushHaystackLog(logs, a);
+  });
+
+  (right.logs || []).forEach((a) => {
+    if (a.fields[0].value === 'cs') rightClientSpan = true;
+    if (a.fields[0].value === 'sr') rightServerSpan = true;
+    maybePushHaystackLog(logs, a);
+  });
+
+  res.operationName = left.operationName;
+  if (right.operationName !== 'not_found') {
+    if (res.operationName === 'not_found') {
+      res.operationName = right.operationName;
+    } else if (leftClientSpan && rightServerSpan) {
+      res.operationName = right.operationName; // prefer the server's span name
+    }
+  }
+
+  res.serviceName = left.serviceName;
+  if (right.serviceName !== 'not_found') {
+    if (res.serviceName === 'not_found') {
+      res.serviceName = right.serviceName;
+    } else if (leftClientSpan && rightServerSpan) {
+      res.serviceName = right.serviceName; // prefer the server's service name
+    }
+  }
+
+  res.logs = logs.sort((a, b) => a.timestamp - b.timestamp);
+
+  res.tags = [];
+
+  (left.tags || []).forEach((b) => {
+    maybePushHaystackTag(res.tags, b);
+  });
+
+  (right.tags || []).forEach((b) => {
+    maybePushHaystackTag(res.tags, b);
+  });
+
+  // Single timestamp makes duration easy: just choose max
+  if (!left.startTime || !right.startTime || left.startTime === right.startTime) {
+    res.startTime = left.startTime || right.startTime;
+    if (!left.duration) {
+      res.duration = right.duration;
+    } else if (right.duration) {
+      res.duration = Math.max(left.duration, right.duration);
+    } else {
+      res.duration = left.duration;
+    }
+
+  // We have 2 different timestamps. If we have client data in either one of them, use right,
+  // else set timestamp and duration to null
+  } else if (rightClientSpan) {
+    res.startTime = right.startTime;
+    res.duration = right.duration;
+  } else if (leftClientSpan) {
+    res.startTime = left.startTime;
+    res.duration = left.duration;
+  }
+
+  return res;
+}
+
+/*
+ * Zipkin spans can be sent in multiple parts. Also client and server spans can
+ * share the same ID. This merges both scenarios.
+ */
+// originally zipkin.internal.MergeById.apply
+function mergeById(spans) {
+  const result = [];
+
+  if (!spans || spans.length === 0) return result;
+
+  const spanIdToSpans = {};
+  spans.forEach((s) => {
+    const id = s.spanId;
+    spanIdToSpans[id] = spanIdToSpans[id] || [];
+    spanIdToSpans[id].push(s);
+  });
+
+  Object.keys(spanIdToSpans).forEach((id) => {
+    const spansToMerge = spanIdToSpans[id];
+    let left = spansToMerge[0];
+    for (let i = 1; i < spansToMerge.length; i += 1) {
+      left = merge(left, spansToMerge[i]);
+    }
+
+    // attempt to get a timestamp so that the UI can sort results
+    result.push(applyTimestampAndDuration(left));
+  });
+
+  return result;
+}
 
 const converter = {};
 
-converter.toHaystackSpan = toHaystackSpan; // exported for testing
+// exported for testing
+converter.toHaystackSpan = toHaystackSpan;
+converter.applyTimestampAndDuration = applyTimestampAndDuration;
+converter.merge = merge;
+converter.mergeById = mergeById;
 
+// NOTE: unlike Zipkin UI, this neither sorts, nor corrects clock skew in the
+// results. Not sure what is in scope of the haystack UI logic.
 converter.toHaystackTrace = zipkinTrace =>
-  zipkinTrace.map(zipkinSpan => toHaystackSpan(zipkinSpan));
+  mergeById(zipkinTrace.map(zipkinSpan => toHaystackSpan(zipkinSpan)));
 
 converter.toHaystackSearchResult = (zipkinTraces, query) => {
   const haystackTraces = zipkinTraces.map(zipkinTrace => converter.toHaystackTrace(zipkinTrace));

--- a/server/connectors/traces/zipkin/converter.js
+++ b/server/connectors/traces/zipkin/converter.js
@@ -15,6 +15,31 @@
  */
 const searchResultsTransformer = require('../haystack/search/searchResultsTransformer');
 
+function toHaystackLog(annotation) {
+  return {
+    timestamp: annotation.timestamp,
+    fields: [
+      {
+        key: 'event',
+        value: annotation.value
+      }
+    ]
+  };
+}
+
+function normalizeTraceId(traceId) {
+  if (traceId.length > 16) {
+    return traceId.padStart(32, '0');
+  }
+  return traceId.padStart(16, '0');
+}
+
+// NOTE: 'not_found' is different than Zipkin's 'unknown' default
+function sanitizeName(name) {
+  return (name && name !== '' && name !== 'unknown') ? name : 'not_found';
+}
+
+// Note: the tag 'success' is not something defined in Zipkin, nor commonly used
 function convertSuccessTag(tags) {
   const successTag = tags.find(tag => tag.key.toLowerCase() === 'success');
   if (successTag) {
@@ -23,6 +48,7 @@ function convertSuccessTag(tags) {
   }
 }
 
+// Note: the tag 'methoduri' is not something defined in Zipkin, nor commonly used
 function convertMethodUriTag(tags) {
   const methodUriTag = tags.find(tag => tag.key.toLowerCase() === 'methoduri');
   if (methodUriTag) {
@@ -30,71 +56,177 @@ function convertMethodUriTag(tags) {
   }
 }
 
-function toHaystackTags(binaryAnnotations) {
-  const tags = binaryAnnotations.map(annotation => ({
-    key: annotation.key,
-    value: annotation.value
-  }));
+function toHaystackSpan(span) {
+  const res = {
+    traceId: normalizeTraceId(span.traceId)
+  };
 
-  convertSuccessTag(tags);
-  convertMethodUriTag(tags);
+  // take care not to create self-referencing spans even if the input data is incorrect
+  const id = span.id.padStart(16, '0');
+  if (span.parentId) {
+    const parentId = span.parentId.padStart(16, '0');
+    if (parentId !== id) {
+      res.parentSpanId = parentId;
+    }
+  }
 
-  return tags;
-}
+  res.spanId = id;
 
-function toHaystackLogs(annotations) {
-  return annotations.map(annotation => ({
-    timestamp: annotation.timestamp,
-    fields: [
-      {
-        key: 'event',
-        value: annotation.value
-      }]
-  }));
-}
+  if (span.localEndpoint) {
+    res.serviceName = sanitizeName(span.localEndpoint.serviceName);
+  } else {
+    res.serviceName = 'not_found';
+  }
 
-function getAnnotationFromValue(annotations, value) {
-  return annotations.find(annotation => annotation.value && annotation.value.toLowerCase() === value);
-}
+  res.operationName = sanitizeName(span.name);
 
-function getServiceNameFromAnnotation(annotation) {
-  return annotation && annotation.endpoint && annotation.endpoint.serviceName;
-}
+  // Don't report timestamp and duration on shared spans (should be server, but not necessarily)
+  if (!span.shared) {
+    if (span.timestamp) res.startTime = span.timestamp;
+    if (span.duration) res.duration = span.duration;
+  }
 
-function getServiceNameFromAnnotationList(binaryAnnotations) {
-  const binaryAnnotationWithService = binaryAnnotations.find(annotation => annotation.endpoint && annotation.endpoint.serviceName);
+  let startTs = span.timestamp || 0;
+  let endTs = startTs && span.duration ? startTs + span.duration : 0;
+  let msTs = 0;
+  let wsTs = 0;
+  let wrTs = 0;
+  let mrTs = 0;
 
-  return getServiceNameFromAnnotation(binaryAnnotationWithService);
-}
+  let begin;
+  let end;
 
-function getServiceName(zipkinSpan) {
-  const serverReceived = getAnnotationFromValue(zipkinSpan.annotations, 'sr');
-  const serverSend = getAnnotationFromValue(zipkinSpan.annotations, 'ss');
-  const clientSend = getAnnotationFromValue(zipkinSpan.annotations, 'cs');
-  const clientReceived = getAnnotationFromValue(zipkinSpan.annotations, 'cr');
+  let kind = span.kind;
 
-  return getServiceNameFromAnnotation(serverReceived)
-      || getServiceNameFromAnnotation(serverSend)
-      || getServiceNameFromAnnotation(clientSend)
-      || getServiceNameFromAnnotation(clientReceived)
-      || getServiceNameFromAnnotationList(zipkinSpan.binaryAnnotations)
-      || getServiceNameFromAnnotationList(zipkinSpan.annotations)
-      || 'not_found';
+  // scan annotations in case there are better timestamps, or inferred kind
+  (span.annotations || []).forEach((a) => {
+    switch (a.value) {
+      case 'cs':
+        kind = 'CLIENT';
+        if (a.timestamp < startTs) startTs = a.timestamp;
+        break;
+      case 'sr':
+        kind = 'SERVER';
+        if (a.timestamp < startTs) startTs = a.timestamp;
+        break;
+      case 'ss':
+        kind = 'SERVER';
+        if (a.timestamp > endTs) endTs = a.timestamp;
+        break;
+      case 'cr':
+        kind = 'CLIENT';
+        if (a.timestamp > endTs) endTs = a.timestamp;
+        break;
+      case 'ms':
+        kind = 'PRODUCER';
+        msTs = a.timestamp;
+        break;
+      case 'mr':
+        kind = 'CONSUMER';
+        mrTs = a.timestamp;
+        break;
+      case 'ws':
+        wsTs = a.timestamp;
+        break;
+      case 'wr':
+        wrTs = a.timestamp;
+        break;
+      default:
+    }
+  });
+
+  switch (kind) {
+    case 'CLIENT':
+      begin = 'cs';
+      end = 'cr';
+      break;
+    case 'SERVER':
+      begin = 'sr';
+      end = 'ss';
+      break;
+    case 'PRODUCER':
+      begin = 'ms';
+      end = 'ws';
+      if (startTs === 0 || (msTs !== 0 && msTs < startTs)) {
+        startTs = msTs;
+      }
+      if (endTs === 0 || (wsTs !== 0 && wsTs > endTs)) {
+        endTs = wsTs;
+      }
+      break;
+    case 'CONSUMER':
+      if (startTs === 0 || (wrTs !== 0 && wrTs < startTs)) {
+        startTs = wrTs;
+      }
+      if (endTs === 0 || (mrTs !== 0 && mrTs > endTs)) {
+        endTs = mrTs;
+      }
+      if (endTs !== 0 || wrTs !== 0) {
+        begin = 'wr';
+        end = 'mr';
+      } else {
+        begin = 'mr';
+      }
+      break;
+    default:
+  }
+
+  const beginAnnotation = startTs && begin;
+  const endAnnotation = endTs && end;
+
+  res.logs = []; // prefer empty to undefined for arrays
+
+  if (beginAnnotation) {
+    res.logs.push(toHaystackLog({
+      value: begin,
+      timestamp: startTs
+    }));
+  }
+
+  (span.annotations || []).forEach((a) => {
+    if (beginAnnotation && a.value === begin) return;
+    if (endAnnotation && a.value === end) return;
+    res.logs.push(toHaystackLog(a));
+  });
+
+  if (endAnnotation) {
+    res.logs.push(toHaystackLog({
+      value: end,
+      timestamp: endTs
+    }));
+  }
+
+  res.tags = []; // prefer empty to undefined for arrays
+  const keys = Object.keys(span.tags || {});
+  if (keys.length > 0) {
+    res.tags = keys.map(key => ({
+      key,
+      value: span.tags[key]
+    }));
+
+    // handle special tags defined by Haystack
+    convertSuccessTag(res.tags);
+    convertMethodUriTag(res.tags);
+  }
+  if (span.remoteEndpoint) {
+    const remoteService = sanitizeName(span.remoteEndpoint.serviceName);
+    if (remoteService !== 'not_found') {
+      res.tags.push({
+        key: 'remote.service_name',
+        value: remoteService
+      });
+    }
+  }
+
+  return res;
 }
 
 const converter = {};
 
-converter.toHaystackTrace = zipkinTrace => zipkinTrace.map(zipkinSpan => ({
-    traceId: zipkinSpan.traceId,
-    spanId: zipkinSpan.id,
-    parentSpanId: zipkinSpan.parentId || null,
-    serviceName: getServiceName(zipkinSpan),
-    operationName: zipkinSpan.name || 'not_found',
-    startTime: zipkinSpan.timestamp,
-    duration: zipkinSpan.duration,
-    tags: toHaystackTags(zipkinSpan.binaryAnnotations),
-    logs: toHaystackLogs(zipkinSpan.annotations)
-}));
+converter.toHaystackSpan = toHaystackSpan; // exported for testing
+
+converter.toHaystackTrace = zipkinTrace =>
+  zipkinTrace.map(zipkinSpan => toHaystackSpan(zipkinSpan));
 
 converter.toHaystackSearchResult = (zipkinTraces, query) => {
   const haystackTraces = zipkinTraces.map(zipkinTrace => converter.toHaystackTrace(zipkinTrace));

--- a/test/server/connectors/traces/zipkin/converter.spec.js
+++ b/test/server/connectors/traces/zipkin/converter.spec.js
@@ -1,0 +1,740 @@
+/*
+ * Copyright 2018 Expedia Group
+ *
+ *       Licensed under the Apache License, Version 2.0 (the License);
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an AS IS BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+import {expect, should} from 'chai';
+
+const converter = require('../../../../../server/connectors/traces/zipkin/converter');
+
+// endpoints from zipkin2.TestObjects
+const frontend = {
+  serviceName: 'frontend',
+  ipv4: '127.0.0.1',
+  port: 8080
+};
+
+const backend = {
+  serviceName: 'backend',
+  ipv4: '192.168.99.101',
+  port: 9000
+};
+
+describe('converter.toHaystackTrace', () => {
+
+  // haystack specific tests have nothing to do with zipkin conventions
+  it('haystack specific: success true to error false', () => {
+    const v2 = {
+      traceId: '1',
+      id: '2',
+      name: 'get',
+      localEndpoint: frontend,
+      tags: {
+        'success': 'true'
+      }
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      spanId: '0000000000000002',
+      serviceName: 'frontend',
+      operationName: 'get',
+      logs: [],
+      tags: [
+        { key: 'error', value: 'false' },
+      ]
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  it('haystack specific: success false to error true', () => {
+    const v2 = {
+      traceId: '1',
+      id: '2',
+      name: 'get',
+      localEndpoint: frontend,
+      tags: {
+        'success': 'false'
+      }
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      spanId: '0000000000000002',
+      serviceName: 'frontend',
+      operationName: 'get',
+      logs: [],
+      tags: [
+        { key: 'error', value: 'true' },
+      ]
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  // in zipkin, this would be http.url
+  it('haystack specific: renamed methoduri to url', () => {
+    const v2 = {
+      traceId: '1',
+      id: '2',
+      name: 'get',
+      localEndpoint: frontend,
+      tags: {
+        'methoduri': 'http://foo.com/pants'
+      }
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      spanId: '0000000000000002',
+      serviceName: 'frontend',
+      operationName: 'get',
+      logs: [],
+      tags: [
+        { key: 'url', value: 'http://foo.com/pants' },
+      ]
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  // in zipkin, name is optional
+  it('haystack specific: missing names are not_found', () => {
+    const v2 = {
+      traceId: '1',
+      id: '2',
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      spanId: '0000000000000002',
+      serviceName: 'not_found',
+      operationName: 'not_found',
+      logs: [],
+      tags: []
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  // originally zipkin2.v1.SpanConverterTest.client
+  it('converts client span', () => {
+    const v2 = {
+      traceId: '1',
+      parentId: '2',
+      id: '3',
+      name: 'get',
+      kind: 'CLIENT',
+      timestamp: 1472470996199000,
+      duration: 207000,
+      localEndpoint: frontend,
+      remoteEndpoint: backend,
+      annotations: [
+        { value: 'ws', timestamp: 1472470996238000 },
+        { value: 'wr', timestamp: 1472470996403000 }
+      ],
+      tags: {
+        'http.path': '/api',
+        'clnt/finagle.version': '6.45.0'
+      }
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      parentSpanId: '0000000000000002',
+      spanId: '0000000000000003',
+      operationName: 'get',
+      serviceName: 'frontend',
+      startTime: 1472470996199000,
+      duration: 207000,
+      logs: [
+        { timestamp: 1472470996199000,
+          fields: [{ key: 'event', value: 'cs' }]},
+        { timestamp: 1472470996238000, // ts order retained
+          fields: [{ key: 'event', value: 'ws' }]},
+        { timestamp: 1472470996403000,
+          fields: [{ key: 'event', value: 'wr' }]},
+        { timestamp: 1472470996406000,
+          fields: [{ key: 'event', value: 'cr' }]}
+      ],
+      tags: [
+        { key: 'http.path', value: '/api' },
+        { key: 'clnt/finagle.version', value: '6.45.0' },
+        { key: 'remote.service_name', value: 'backend' }
+      ]
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  it('should delete self-referencing parentId', () => {
+    const converted = converter.toHaystackSpan({
+      traceId: '1',
+      parentId: '3', // self-referencing
+      id: '3'
+    });
+
+    should().equal(converted.parentSpanId, undefined);
+  });
+
+  // originally zipkin2.v1.SpanConverterTest.SpanConverterTest.client_unfinished
+  it('converts incomplete client span', () => {
+    const v2 = {
+      traceId: '1',
+      parentId: '2',
+      id: '3',
+      name: 'get',
+      kind: 'CLIENT',
+      timestamp: 1472470996199000,
+      localEndpoint: frontend,
+      annotations: [
+        { value: 'ws', timestamp: 1472470996238000 }
+      ]
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      parentSpanId: '0000000000000002',
+      spanId: '0000000000000003',
+      serviceName: 'frontend',
+      operationName: 'get',
+      startTime: 1472470996199000,
+      logs: [
+        { timestamp: 1472470996199000,
+          fields: [{ key: 'event', value: 'cs' }]},
+        { timestamp: 1472470996238000,
+          fields: [{ key: 'event', value: 'ws' }]}
+      ],
+      tags: [] // prefers empty array to nil
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  // originally zipkin2.v1.SpanConverterTest.client_kindInferredFromAnnotation
+  it('infers cr log event', () => {
+    const v2 = {
+      traceId: '1',
+      parentId: '2',
+      id: '3',
+      name: 'get',
+      timestamp: 1472470996199000,
+      duration: 207000,
+      localEndpoint: frontend,
+      annotations: [
+        { value: 'cs', timestamp: 1472470996199000 }
+      ]
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      parentSpanId: '0000000000000002',
+      spanId: '0000000000000003',
+      serviceName: 'frontend',
+      operationName: 'get',
+      startTime: 1472470996199000,
+      duration: 207000,
+      logs: [
+        { timestamp: 1472470996199000,
+          fields: [{ key: 'event', value: 'cs' }]},
+        { timestamp: 1472470996406000,
+          fields: [{ key: 'event', value: 'cr' }]}
+      ],
+      tags: []
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  // originally zipkin2.v1.SpanConverterTest.lateRemoteEndpoint_cr
+  it('converts client span reporting remote endpoint with late cr', () => {
+    const v2 = {
+      traceId: '1',
+      parentId: '2',
+      id: '3',
+      name: 'get',
+      kind: 'CLIENT',
+      localEndpoint: frontend,
+      remoteEndpoint: backend,
+      annotations: [
+        { value: 'cr', timestamp: 1472470996199000 }
+      ]
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      parentSpanId: '0000000000000002',
+      spanId: '0000000000000003',
+      serviceName: 'frontend',
+      operationName: 'get',
+      logs: [
+        { timestamp: 1472470996199000,
+          fields: [{ key: 'event', value: 'cr' }]}
+      ],
+      tags: [
+        { key: 'remote.service_name', value: 'backend' }
+      ]
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  // originally zipkin2.v1.SpanConverterTest.lateRemoteEndpoint_sa
+  it('converts late remoteEndpoint to remote.service_name', () => {
+    const v2 = {
+      traceId: '1',
+      parentId: '2',
+      id: '3',
+      remoteEndpoint: backend
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      parentSpanId: '0000000000000002',
+      spanId: '0000000000000003',
+      serviceName: 'not_found',
+      operationName: 'not_found',
+      logs: [],
+      tags: [
+        { key: 'remote.service_name', value: 'backend' }
+      ]
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  // originally zipkin2.v1.SpanConverterTest.noAnnotationsExceptAddresses
+  it('converts when remoteEndpoint exist without kind', () => {
+    const v2 = {
+      traceId: '1',
+      parentId: '2',
+      id: '3',
+      name: 'get',
+      timestamp: 1472470996199000,
+      duration: 207000,
+      localEndpoint: frontend,
+      remoteEndpoint: backend
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      parentSpanId: '0000000000000002',
+      spanId: '0000000000000003',
+      operationName: 'get',
+      serviceName: 'frontend',
+      startTime: 1472470996199000,
+      duration: 207000,
+      logs: [],
+      tags: [
+        { key: 'remote.service_name', value: 'backend' }
+      ]
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  // originally zipkin2.v1.SpanConverterTest.server
+  it('converts root server span', () => {
+    // let's pretend there was no caller, so we don't set shared flag
+    const v2 = {
+      traceId: '1',
+      id: '2',
+      name: 'get',
+      kind: 'SERVER',
+      localEndpoint: backend,
+      remoteEndpoint: frontend,
+      timestamp: 1472470996199000,
+      duration: 207000,
+      tags: {
+        'http.path': '/api',
+        'finagle.version': '6.45.0'
+      }
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      spanId: '0000000000000002',
+      serviceName: 'backend',
+      operationName: 'get',
+      startTime: 1472470996199000,
+      duration: 207000,
+      logs: [
+        { timestamp: 1472470996199000,
+          fields: [{ key: 'event', value: 'sr' }]},
+        { timestamp: 1472470996406000,
+          fields: [{ key: 'event', value: 'ss' }]}
+      ],
+      tags: [
+        { key: 'http.path', value: '/api' },
+        { key: 'finagle.version', value: '6.45.0' },
+        { key: 'remote.service_name', value: 'frontend' }
+      ]
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  // originally zipkin2.v1.SpanConverterTest.missingEndpoints
+  it('converts span with no endpoints', () => {
+    const v2 = {
+      traceId: '1',
+      parentId: '1',
+      id: '2',
+      name: 'foo',
+      timestamp: 1472470996199000,
+      duration: 207000
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      parentSpanId: '0000000000000001',
+      spanId: '0000000000000002',
+      serviceName: 'not_found',
+      operationName: 'foo',
+      startTime: 1472470996199000,
+      duration: 207000,
+      logs: [],
+      tags: []
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  // originally zipkin2.v1.SpanConverterTest.coreAnnotation
+  it('converts v2 span retaining an sr annotation', () => {
+    const v2 = {
+      traceId: '1',
+      parentId: '1',
+      id: '2',
+      name: 'foo',
+      timestamp: 1472470996199000,
+      annotations: [
+        { value: 'cs', timestamp: 1472470996199000 }
+      ]
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      parentSpanId: '0000000000000001',
+      spanId: '0000000000000002',
+      serviceName: 'not_found',
+      operationName: 'foo',
+      startTime: 1472470996199000,
+      logs: [
+        { timestamp: 1472470996199000,
+          fields: [{ key: 'event', value: 'cs' }]}
+      ],
+      tags: []
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  // originally zipkin2.v1.SpanConverterTest.server_shared_haystack_no_timestamp_duration
+  it('converts shared server span without writing timestamp and duration', () => {
+    const v2 = {
+      traceId: '1',
+      parentId: '2',
+      id: '3',
+      name: 'get',
+      kind: 'SERVER',
+      shared: true,
+      localEndpoint: backend,
+      timestamp: 1472470996199000,
+      duration: 207000
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      parentSpanId: '0000000000000002',
+      spanId: '0000000000000003',
+      serviceName: 'backend',
+      operationName: 'get',
+      logs: [
+        { timestamp: 1472470996199000,
+          fields: [{ key: 'event', value: 'sr' }]},
+        { timestamp: 1472470996406000,
+          fields: [{ key: 'event', value: 'ss' }]}
+      ],
+      tags: []
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  // originally zipkin2.v1.SpanConverterTest.server_incomplete_shared
+  it('converts incomplete shared server span', () => {
+    const v2 = {
+      traceId: '1',
+      parentId: '2',
+      id: '3',
+      name: 'get',
+      kind: 'SERVER',
+      shared: true,
+      localEndpoint: backend,
+      timestamp: 1472470996199000
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      parentSpanId: '0000000000000002',
+      spanId: '0000000000000003',
+      serviceName: 'backend',
+      operationName: 'get',
+      logs: [
+        { timestamp: 1472470996199000,
+          fields: [{ key: 'event', value: 'sr' }]}
+      ],
+      tags: []
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  // originally zipkin2.v1.SpanConverterTest.lateRemoteEndpoint_ss
+  it('converts late incomplete server span with remote endpoint', () => {
+    const v2 = {
+      traceId: '1',
+      id: '2',
+      name: 'get',
+      kind: 'SERVER',
+      localEndpoint: backend,
+      remoteEndpoint: frontend,
+      annotations: [
+        { value: 'ss', timestamp: 1472470996199000 }
+      ]
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      spanId: '0000000000000002',
+      serviceName: 'backend',
+      operationName: 'get',
+      logs: [
+        { timestamp: 1472470996199000,
+          fields: [{ key: 'event', value: 'ss' }]}
+      ],
+      tags: [
+        { key: 'remote.service_name', value: 'frontend' }
+      ]
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  // originally zipkin2.v1.SpanConverterTest.lateRemoteEndpoint_ca
+  it('converts late remote endpoint server span', () => {
+    const v2 = {
+      traceId: '1',
+      id: '2',
+      kind: 'SERVER',
+      remoteEndpoint: frontend
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      spanId: '0000000000000002',
+      serviceName: 'not_found',
+      operationName: 'not_found',
+      logs: [],
+      tags: [
+        { key: 'remote.service_name', value: 'frontend' }
+      ]
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  // originally zipkin2.v1.SpanConverterTest.localSpan_emptyComponent
+  it('converts local span', () => {
+    const v2 = {
+      traceId: '1',
+      id: '2',
+      name: 'local',
+      localEndpoint: {serviceName: 'frontend'},
+      timestamp: 1472470996199000,
+      duration: 207000
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      spanId: '0000000000000002',
+      serviceName: 'frontend',
+      operationName: 'local',
+      startTime: 1472470996199000,
+      duration: 207000,
+      logs: [],
+      tags: []
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  // originally zipkin2.v1.SpanConverterTest.producer_remote
+  it('converts incomplete producer span', () => {
+    const v2 = {
+      traceId: '1',
+      parentId: '2',
+      id: '3',
+      name: 'send',
+      kind: 'PRODUCER',
+      timestamp: 1472470996199000,
+      localEndpoint: frontend
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      parentSpanId: '0000000000000002',
+      spanId: '0000000000000003',
+      serviceName: 'frontend',
+      operationName: 'send',
+      startTime: 1472470996199000,
+      logs: [
+        { timestamp: 1472470996199000,
+          fields: [{ key: 'event', value: 'ms' }]}
+      ],
+      tags: []
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  // originally zipkin2.v1.SpanConverterTest.producer_duration
+  it('converts producer span', () => {
+    const v2 = {
+      traceId: '1',
+      parentId: '2',
+      id: '3',
+      name: 'send',
+      kind: 'PRODUCER',
+      localEndpoint: frontend,
+      timestamp: 1472470996199000,
+      duration: 51000
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      parentSpanId: '0000000000000002',
+      spanId: '0000000000000003',
+      serviceName: 'frontend',
+      operationName: 'send',
+      startTime: 1472470996199000,
+      duration: 51000,
+      logs: [
+        { timestamp: 1472470996199000,
+          fields: [{ key: 'event', value: 'ms' }]},
+        { timestamp: 1472470996250000,
+          fields: [{ key: 'event', value: 'ws' }]}
+      ],
+      tags: []
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  // originally zipkin2.v1.SpanConverterTest.consumer
+  it('converts incomplete consumer span', () => {
+    const v2 = {
+      traceId: '1',
+      parentId: '2',
+      id: '3',
+      name: 'next-message',
+      kind: 'CONSUMER',
+      timestamp: 1472470996199000,
+      localEndpoint: backend
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      parentSpanId: '0000000000000002',
+      spanId: '0000000000000003',
+      serviceName: 'backend',
+      operationName: 'next-message',
+      startTime: 1472470996199000,
+      logs: [
+        { timestamp: 1472470996199000,
+          fields: [{ key: 'event', value: 'mr' }]}
+      ],
+      tags: []
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  // originally zipkin2.v1.SpanConverterTest.consumer_remote
+  it('converts incomplete consumer span with remote endpoint', () => {
+    const v2 = {
+      traceId: '1',
+      parentId: '2',
+      id: '3',
+      name: 'next-message',
+      kind: 'CONSUMER',
+      timestamp: 1472470996199000,
+      localEndpoint: backend,
+      remoteEndpoint: { serviceName: 'kafka' }
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      parentSpanId: '0000000000000002',
+      spanId: '0000000000000003',
+      serviceName: 'backend',
+      operationName: 'next-message',
+      startTime: 1472470996199000,
+      logs: [
+        { timestamp: 1472470996199000,
+          fields: [{ key: 'event', value: 'mr' }]}
+      ],
+      tags: [
+        { key: 'remote.service_name', value: 'kafka' }
+      ]
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+
+  // originally zipkin2.v1.SpanConverterTest.consumer_duration
+  it('converts consumer span', () => {
+    const v2 = {
+      traceId: '1',
+      parentId: '2',
+      id: '3',
+      name: 'send',
+      kind: 'CONSUMER',
+      localEndpoint: backend,
+      timestamp: 1472470996199000,
+      duration: 51000
+    };
+
+    const haystack = {
+      traceId: '0000000000000001',
+      parentSpanId: '0000000000000002',
+      spanId: '0000000000000003',
+      serviceName: 'backend',
+      operationName: 'send',
+      startTime: 1472470996199000,
+      duration: 51000,
+      logs: [
+        { timestamp: 1472470996199000,
+          fields: [{ key: 'event', value: 'wr' }]},
+        { timestamp: 1472470996250000,
+          fields: [{ key: 'event', value: 'mr' }]}
+      ],
+      tags: []
+    };
+
+    expect(converter.toHaystackSpan(v2)).to.deep.equal(haystack);
+  });
+});


### PR DESCRIPTION
This starts the conversion towards zipkin v2 format. Later work will
deal with merging spans, which is needed as Haystack is similar to
Zipkin's v1 format. Also, there are some small query parameter changes
needed, notably as v2 doesn't have defaults for some parameters that
have defaults in v1.

This is being raised mainly to get some code out there.

See #396