### PR TITLE
fixing trends duration unit

### DIFF
--- a/src/components/trends/details/graphs/durationGraph.jsx
+++ b/src/components/trends/details/graphs/durationGraph.jsx
@@ -38,7 +38,7 @@ durationChartOptions.scales.yAxes = [{
     display: true,
     ticks: {
         callback(value) {
-            const formattedValue = formatters.toDurationStringFromMs(value);
+            const formattedValue = formatters.toDurationString(value);
             if (formattedValue.length < 8) {
                 return `${' '.repeat(8 - formattedValue.length)}${formattedValue}`;
             }

--- a/src/components/trends/utils/trendSparklines.jsx
+++ b/src/components/trends/utils/trendSparklines.jsx
@@ -42,7 +42,7 @@ sparklines.CountSparkline.propTypes = {
 sparklines.DurationSparkline = ({latest, points}) =>
     (<div className="sparkline-container">
         { !isNaN(latest) &&
-            <div className="sparkline-title">latest <b>{formatters.toDurationStringFromMs(latest)}</b></div>
+            <div className="sparkline-title">latest <b>{formatters.toDurationString(latest)}</b></div>
         }
         <div className="sparkline-graph">
             <Sparklines className="sparkline" data={points} min={0} height={48}>


### PR DESCRIPTION
Trends API returns values in Microsecond, fixing unit conversion.