### PR TITLE
Autosuggest UX Improvements/Fixes

### DIFF
--- a/src/components/universalSearch/searchBar/autosuggest.jsx
+++ b/src/components/universalSearch/searchBar/autosuggest.jsx
@@ -175,7 +175,7 @@ export default class Autocomplete extends React.Component {
             value = targetInput.substring(operatorIndex + 1, targetInput.length).trim().replace('"', '');
             if (this.props.options[key] && this.props.options[key].values) {
                 this.props.options[key].values.forEach((option) => {
-                    if (option.toLowerCase().includes(value.toLowerCase())) {
+                    if (option.toLowerCase().includes(value.toLowerCase()) && option !== value) {
                         suggestionArray.push(option);
                     }
                 });
@@ -188,7 +188,7 @@ export default class Autocomplete extends React.Component {
             type = 'Keys';
             value = targetInput.toLowerCase();
             Object.keys(this.props.options).forEach((option) => {
-                if (option.toLowerCase().includes(value)) {
+                if (option.toLowerCase().includes(value) && option !== value) {
                     suggestionArray.push(option);
                 }
             });
@@ -342,8 +342,10 @@ export default class Autocomplete extends React.Component {
         const keyPressed = e.keyCode || e.which;
         if ((keyPressed === ENTER || keyPressed === TAB) && this.state.suggestionStrings.length) {
             e.preventDefault();
-            this.handleDropdownSelection();
-            this.handleBlur();
+            if (this.state.suggestionIndex !== null || this.state.suggestionStrings.length === 1) {
+                this.handleDropdownSelection();
+                this.handleBlur();
+            }
         } else if (keyPressed === ENTER) {
             e.preventDefault();
             this.updateChips();
@@ -372,6 +374,7 @@ export default class Autocomplete extends React.Component {
             if (!this.inputRef.value && chips.length) {
                 e.preventDefault();
                 this.modifyChip();
+                this.updateFieldKv(e);
             }
         }
     }

--- a/src/components/universalSearch/searchBar/autosuggest.less
+++ b/src/components/universalSearch/searchBar/autosuggest.less
@@ -77,7 +77,15 @@
     display: inline-block;
     padding: 0 @spacing-xs 0 @spacing-xs;
     background-color: rgba(0, 0, 0, 0.25);
-}
+    max-width: 10vw;
+    vertical-align: bottom;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    &:hover {
+        max-width: none;
+        overflow: visible;
+    }
+  }
 
 .usb-chip__delete {
     padding-top: 0;

--- a/src/components/universalSearch/searchBar/chips.jsx
+++ b/src/components/universalSearch/searchBar/chips.jsx
@@ -25,13 +25,6 @@ export default class Chips extends React.Component {
         deleteChip: PropTypes.func.isRequired
     };
 
-    static truncateLongValues(chipValue) {
-        if (chipValue.length > 12) {
-            return `${chipValue.substring(0, 12)}...`;
-        }
-        return chipValue;
-    }
-
     constructor(props) {
         super(props);
         this.state = {
@@ -80,7 +73,7 @@ export default class Chips extends React.Component {
                                 <span key={Math.random()}>
                                     <span className="usb-chip__key">{nestedChip.key}</span>
                                     {nestedChip.operator !== '=' ? <span className="usb-chip__operator">{nestedChip.operator}</span> : null}
-                                    <span className="usb-chip__value">{Chips.truncateLongValues(nestedChip.value)}</span>
+                                    <span className="usb-chip__value">{nestedChip.value}</span>
                                 </span>
                             ))
                         }
@@ -93,7 +86,7 @@ export default class Chips extends React.Component {
                 <div className="usb-chip" key={Math.random()}>
                     <span className="usb-chip__key">{chip.key}</span>
                     {chip.operator !== '=' ? <span className="usb-chip__operator">{chip.operator}</span> : null}
-                    <span className="usb-chip__value">{Chips.truncateLongValues(chip.value)}</span>
+                    <span className="usb-chip__value">{chip.value}</span>
                     <button type="button" className="usb-chip__delete" onClick={() => this.props.deleteChip(index)}>x</button>
                 </div>
             );

--- a/test/src/components/universalSearch/universalSearch.spec.jsx
+++ b/test/src/components/universalSearch/universalSearch.spec.jsx
@@ -175,7 +175,7 @@ describe('<UniversalSearch />', () => {
     after(() => {
         server = null;
     });
-    
+
     it('should render the universalSearch panel', () => {
         const wrapper = mount(<MemoryRouter><UniversalSearch.WrappedComponent location={stubLocation} history={stubHistory}/></MemoryRouter>);
         expect(wrapper.find('.universal-search-panel')).to.have.length(1);
@@ -389,7 +389,7 @@ describe('<Autosuggest />', () => {
         const wrapper = mount(<Autosuggest options={stubOptions} uiState={createStubUiStateStore(stubShortChip)} search={() => {}} serviceStore={createServiceStubStore()} operationStore={createOperationStubStore()}/>);
         const input = wrapper.find('.usb-searchbar__input');
         expect(spy.callCount).to.equal(0);
-        input.prop('onKeyDown')({keyCode: 8, preventDefault: () => {}});
+        input.prop('onKeyDown')({keyCode: 8, preventDefault: () => {}, target: {value: ''}});
 
         expect(spy.callCount).to.equal(1);
         Autosuggest.prototype.modifyChip.restore();
@@ -401,7 +401,7 @@ describe('<Autosuggest />', () => {
         const input = wrapper.find('.usb-searchbar__input');
 
         expect(spy.callCount).to.equal(0);
-        input.prop('onKeyDown')({keyCode: 8, preventDefault: () => {}});
+        input.prop('onKeyDown')({keyCode: 8, preventDefault: () => {}, target: {value: ''}});
 
         expect(spy.callCount).to.equal(1);
         expect(wrapper.instance().inputRef.value).to.equal('(serviceName=test error=true)');


### PR DESCRIPTION
- Display whole K/V pair value when hovering it
- Prevent enter/tab from populating first selection when there is no selected value (via up/down or hover), unless there is only one option
- Fix bugs with enter key after backspacing
- Fix bugs with occasionally having to press enter key twice to pick a selected key or value