### PR TITLE
database type has precedence over outbound type

### DIFF
--- a/server/connectors/serviceInsights/graphDataExtractor.js
+++ b/server/connectors/serviceInsights/graphDataExtractor.js
@@ -251,11 +251,11 @@ function buildNodes(spans) {
             node.type = type.gateway;
         } else if (mesh && mesh.isType(span)) {
             node.type = type.mesh;
-        } else if (outbound && outbound.isType(span)) {
-            node.type = type.outbound;
         } else if (database && database.isType(span)) {
             node.type = type.database;
             node.databaseType = database.databaseType(span);
+        } else if (outbound && outbound.isType(span)) {
+            node.type = type.outbound;
         } else {
             node.type = type.service;
         }

--- a/test/server/connectors/serviceInsights/graphDataExtractor.spec.js
+++ b/test/server/connectors/serviceInsights/graphDataExtractor.spec.js
@@ -146,7 +146,7 @@ describe('graphDataExtractor.extractNodesAndLinks', () => {
 
     function databaseSpan() {
         // some-backend-server's span from its nosql database client query
-        return span('some-backend-server', 'SELECT *', [{key: 'db.type', value: 'nosql'}]);
+        return span('some-backend-server', 'SELECT *', [{key: 'db.type', value: 'nosql'}, {key: 'span.kind', value: 'client'}]);
     }
 
     function mergedSpan() {


### PR DESCRIPTION
Fixes `database` nodes, which were being incorrectly set to `uninstrumented`. This caused both the uninstrumented count and the node icon to be incorrect.

**Before**
![before](https://user-images.githubusercontent.com/8717772/62076755-0aae6b80-b20e-11e9-8544-f10940bd2483.png)

**After**
![after](https://user-images.githubusercontent.com/8717772/62076763-126e1000-b20e-11e9-9640-0222e4f63e02.png)
