### PR TITLE
Service Insights api fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "npm run clean && npm run codegen && npm run coverage && webpack --mode=production",
     "start": "node server/start.js",
     "start:dev": "npm run clean && npm run codegen && npm run test && concurrently -r \"npm run watch\" \"wait-on public/bundles/report.html && npm run start:devserver\"",
-    "start:dev:fast": "concurrently -r \"npm run watch\" \"wait-on public/bundles/report.html && npm run start:devserver\"",
+    "start:dev:fast": "npm run clean && npm run codegen && concurrently -r \"npm run watch\" \"wait-on public/bundles/report.html && npm run start:devserver\"",
     "start:devserver": "NODE_ENV=development nodemon --inspect --ignore 'public/*' server/start.js",
     "watch": "NODE_ENV=development webpack -w --mode=development"
   },

--- a/server/connectors/serviceInsights/fetcher.js
+++ b/server/connectors/serviceInsights/fetcher.js
@@ -23,19 +23,21 @@ const logger = require('../../utils/logger').withIdentifier('fetcher.serviceInsi
 const metrics = require('../../utils/metrics');
 
 const fetcher = (fetcherName) => ({
-    fetch(serviceName, from, to) {
+    fetch(serviceName, startTime, endTime) {
         const deferred = Q.defer();
         const timer = metrics.timer(`fetcher_${fetcherName}`).start();
 
         tracesConnector
             .findTraces({
+                useExpressionTree: 'true',
                 serviceName,
-                from,
-                to
+                startTime,
+                endTime,
+                spanLevelFilters: '[]'
             })
             .then((traces) => {
                 if (traces && traces.length > 0) {
-                    tracesConnector.getRawTraces(traces.map((trace) => trace.traceId)).then((rawTraces) => {
+                    tracesConnector.getRawTraces(JSON.stringify(traces.map((trace) => trace.traceId))).then((rawTraces) => {
                         timer.end();
                         logger.info(`fetch successful: ${fetcherName}`);
                         deferred.resolve({

--- a/server/connectors/serviceInsights/serviceInsightsConnector.js
+++ b/server/connectors/serviceInsights/serviceInsightsConnector.js
@@ -21,12 +21,12 @@ const extractor = require('./graphDataExtractor');
 
 const connector = {};
 
-function fetchServiceInsights(serviceName, from, to) {
+function fetchServiceInsights(serviceName, startTime, endTime) {
     return fetcher(serviceName)
-        .fetch(serviceName, from, to)
+        .fetch(serviceName, startTime, endTime)
         .then((data) => extractor.extractNodesAndLinks(data));
 }
 
-connector.getServiceInsightsForService = (serviceName, from, to) => Q.fcall(() => fetchServiceInsights(serviceName, from, to));
+connector.getServiceInsightsForService = (serviceName, startTime, endTime) => Q.fcall(() => fetchServiceInsights(serviceName, startTime, endTime));
 
 module.exports = connector;

--- a/server/routes/serviceInsightsApi.js
+++ b/server/routes/serviceInsightsApi.js
@@ -23,11 +23,7 @@ const router = express.Router();
 
 router.get('/serviceInsights', (req, res, next) => {
     handleResponsePromise(res, next, 'svc_insights_SVC')(() => {
-        const millis = Date.now();
-        const startTime = req.query.from ? req.query.from : (millis - 60 * 60 * 1000) * 1000; // μs
-        const endTime = req.query.to ? req.query.to : millis * 1000;
-        const serviceName = req.query.service;
-
+        const {serviceName, startTime, endTime} = req.query;
         return serviceInsightsConnector.getServiceInsightsForService(serviceName, startTime, endTime);
     });
 });

--- a/src/components/serviceInsights/serviceInsights.jsx
+++ b/src/components/serviceInsights/serviceInsights.jsx
@@ -57,14 +57,16 @@ export default class ServiceInsights extends Component {
 
         const activeWindowTimeRange = timeWindow.toTimeRange(activeWindow.value);
 
-        const queryParams = {
-            service: search.serviceName,
-            from: activeWindowTimeRange.from,
-            to: activeWindowTimeRange.until
-        };
+        const micro = (milli) => milli * 1000;
+        const startTime = micro(activeWindowTimeRange.from);
+        const endTime = micro(activeWindowTimeRange.until);
 
         // Get service insights
-        this.props.store.fetchServiceInsights(queryParams);
+        this.props.store.fetchServiceInsights({
+            serviceName: search.serviceName,
+            startTime,
+            endTime
+        });
     };
 
     render() {

--- a/src/components/serviceInsights/stores/serviceInsightsStore.js
+++ b/src/components/serviceInsights/stores/serviceInsightsStore.js
@@ -25,9 +25,11 @@ export class ServiceInsightsStore extends ErrorHandlingStore {
     @observable filterQuery = null;
 
     @action fetchServiceInsights(filterQuery) {
+        const {serviceName, startTime, endTime} = filterQuery;
+
         this.promiseState = fromPromise(
             axios
-                .get(`/api/serviceInsights?service=${filterQuery.service}&from=${filterQuery.from}&to=${filterQuery.to}`)
+                .get(`/api/serviceInsights?serviceName=${serviceName}&startTime=${startTime}&endTime=${endTime}`)
                 .then((result) => {
                     this.filterQuery = filterQuery;
                     this.serviceInsights = result.data;

--- a/test/src/components/serviceInsights/serviceInsights.spec.jsx
+++ b/test/src/components/serviceInsights/serviceInsights.spec.jsx
@@ -75,9 +75,9 @@ describe('<ServiceInsights/>', () => {
             shallow(<ServiceInsights search={search} store={store} />);
 
             const queryParams = store.fetchServiceInsights.getCall(0).args[0];
-            expect(queryParams.service).to.equal(search.serviceName);
-            expect(queryParams.to).to.exist;
-            expect(queryParams.from).to.exist;
+            expect(queryParams.serviceName).to.equal(search.serviceName);
+            expect(queryParams.startTime).to.exist;
+            expect(queryParams.endTime).to.exist;
         });
 
         it('should call toCustomTimeRange when search includes timeframe', () => {

--- a/test/src/components/serviceInsights/stores/serviceInsightsStore.spec.js
+++ b/test/src/components/serviceInsights/stores/serviceInsightsStore.spec.js
@@ -52,7 +52,7 @@ const {ServiceInsightsStore} = proxyquire('../../../../../src/components/service
 
 describe('serviceInsightsStore', () => {
     let store = null;
-    let handleErrorSpy = spy(ServiceInsightsStore, 'handleError');
+    const handleErrorSpy = spy(ServiceInsightsStore, 'handleError');
 
     before(() => {
         store = new ServiceInsightsStore();
@@ -62,15 +62,15 @@ describe('serviceInsightsStore', () => {
     it('should fetch a list of service insights', (done) => {
         // given, when
         store.fetchServiceInsights({
-            service: 'node-web-ui',
-            from: 1000,
-            to: 2000
+            serviceName: 'node-web-ui',
+            startTime: 1000,
+            endTime: 2000
         });
         observe(store.promiseState, () => {
             store.promiseState.case({
                 fulfilled: (result) => {
                     // then
-                    expect(mockAxiosSpy.calledWith('/api/serviceInsights?service=node-web-ui&from=1000&to=2000')).to.equal(true);
+                    expect(mockAxiosSpy.calledWith('/api/serviceInsights?serviceName=node-web-ui&startTime=1000&endTime=2000')).to.equal(true);
                     expect(result.data.summary.violations).to.equal(1);
                     done();
                 },
@@ -85,14 +85,14 @@ describe('serviceInsightsStore', () => {
     it('should handle errors', (done) => {
         // given, when
         store.fetchServiceInsights({
-            service: 'node-web-ui-errors',
-            from: 1000,
-            to: 2000
+            serviceName: 'node-web-ui-errors',
+            startTime: 1000,
+            endTime: 2000
         });
         observe(store.promiseState, () => {
             store.promiseState.case({
                 fulfilled: (result) => {
-                    expect.fail('should have not succeeded');
+                    expect.fail(`should have not succeeded with result: ${result}`);
                 },
                 rejected: (result) => {
                     // then


### PR DESCRIPTION
First commit fixes a minor bug with `npm run start:dev:fast` not updating `public/assets.json`.

Second commit is a co-authored squash of:
- fixes Service Insights fetcher to use the `haystack` connector for Traces correctly
- fixes the `haystack-ui-proxy` connector to be consistent with the fixed `haystack` connector usage
- simplifies out the server-side conversions from milliseconds to microseconds by making a single client-side conversion
- consistently uses `serviceName`, `startTime`, `endTime` for the Service Insights api