### PR TITLE
fix Service Insights summary occludes search

### DIFF
--- a/src/components/serviceInsights/serviceInsights.less
+++ b/src/components/serviceInsights/serviceInsights.less
@@ -31,7 +31,7 @@
     max-width: 500px;
     margin-top: 20px;
     padding: 8px 16px;
-    z-index: 12;
+    z-index: 1;
     background: #f2f4fbde;
     border: solid 1px #cacaca;
     pointer-events: none;

--- a/src/components/serviceInsights/serviceInsightsGraph/tooltip.less
+++ b/src/components/serviceInsights/serviceInsightsGraph/tooltip.less
@@ -19,6 +19,7 @@
 
 .graph-tooltip {
     pointer-events: none;
+    user-select: none;
     position: fixed;
     left: 0;
     right: 0;


### PR DESCRIPTION
Previously the Service Insights summary occluded both the search autosuggest and the timerange picker (at mobile widths). This fixes both by lowering the z-index of the summary.

**Before**
![broken-autosuggest](https://user-images.githubusercontent.com/8717772/62647960-5dc3a500-b917-11e9-988f-5e5cc05fda09.png)
![broken-timerange](https://user-images.githubusercontent.com/8717772/62647965-6025ff00-b917-11e9-90d4-ea2c36886152.png)

**After**
![fixed-autosuggest](https://user-images.githubusercontent.com/8717772/62647977-64521c80-b917-11e9-9003-bc48c744c8e0.png)
![fixed-timerange](https://user-images.githubusercontent.com/8717772/62647982-66b47680-b917-11e9-8478-192a07d8827f.png)

Also this commit fixes a cosmetic issue with selecting tooltip text by accident, such as when attempting to drag. The tooltip itself doesn't support text selection, so this would only happen when text around the tooltip is selected.