### PR TITLE
Implementing limit feature to retrieve more traces for service insights

### DIFF
--- a/server/config/base.js
+++ b/server/config/base.js
@@ -107,6 +107,8 @@ module.exports = {
             // serviceInsights uses traces.connectorName
             // Service Insights is beta, so disabled by default
             enableServiceInsights: false,
+            // max number of traces to retrieve
+            traceLimit: 1000,
             // functions to generate nodes from different types of spans
             // customize these to match tech stack, available span tags, and how you want nodes displayed
             spanTypes: {

--- a/server/config/base.js
+++ b/server/config/base.js
@@ -108,7 +108,7 @@ module.exports = {
             // Service Insights is beta, so disabled by default
             enableServiceInsights: false,
             // max number of traces to retrieve
-            traceLimit: 1000,
+            traceLimit: 200,
             // functions to generate nodes from different types of spans
             // customize these to match tech stack, available span tags, and how you want nodes displayed
             spanTypes: {

--- a/server/connectors/serviceInsights/graphDataExtractor.js
+++ b/server/connectors/serviceInsights/graphDataExtractor.js
@@ -330,7 +330,7 @@ function buildLinks(spans) {
  * @param {*} spans - Array of fully hydrated span objects related to multiple traces
  * @param {*} serviceName - Service name to search for
  */
-const extractNodesAndLinks = ({spans, serviceName}) => {
+const extractNodesAndLinks = ({spans, serviceName, traceLimitReached}) => {
     // build map of nodes
     const nodes = buildNodes(spans);
 
@@ -339,6 +339,7 @@ const extractNodesAndLinks = ({spans, serviceName}) => {
 
     // Process nodes and links for consumption of graphing library
     const summary = processNodesAndLinks(serviceName, nodes, links);
+    summary.traceLimitReached = traceLimitReached;
 
     return {
         summary,

--- a/server/connectors/serviceInsights/serviceInsightsConnector.js
+++ b/server/connectors/serviceInsights/serviceInsightsConnector.js
@@ -21,12 +21,13 @@ const extractor = require('./graphDataExtractor');
 
 const connector = {};
 
-function fetchServiceInsights(serviceName, startTime, endTime) {
+function fetchServiceInsights(serviceName, startTime, endTime, limit) {
     return fetcher(serviceName)
-        .fetch(serviceName, startTime, endTime)
+        .fetch(serviceName, startTime, endTime, limit)
         .then((data) => extractor.extractNodesAndLinks(data));
 }
 
-connector.getServiceInsightsForService = (serviceName, startTime, endTime) => Q.fcall(() => fetchServiceInsights(serviceName, startTime, endTime));
+connector.getServiceInsightsForService = (serviceName, startTime, endTime, limit) =>
+    Q.fcall(() => fetchServiceInsights(serviceName, startTime, endTime, limit));
 
 module.exports = connector;

--- a/server/routes/serviceInsightsApi.js
+++ b/server/routes/serviceInsightsApi.js
@@ -23,8 +23,8 @@ const router = express.Router();
 
 router.get('/serviceInsights', (req, res, next) => {
     handleResponsePromise(res, next, 'svc_insights_SVC')(() => {
-        const {serviceName, startTime, endTime} = req.query;
-        return serviceInsightsConnector.getServiceInsightsForService(serviceName, startTime, endTime);
+        const {serviceName, startTime, endTime, limit} = req.query;
+        return serviceInsightsConnector.getServiceInsightsForService(serviceName, startTime, endTime, limit);
     });
 });
 

--- a/src/components/serviceInsights/serviceInsightsGraph/lines.jsx
+++ b/src/components/serviceInsights/serviceInsightsGraph/lines.jsx
@@ -22,7 +22,8 @@ export default class Lines extends Component {
     static propTypes = {
         edges: PropTypes.array.isRequired,
         onHover: PropTypes.func.isRequired,
-        onLeave: PropTypes.func.isRequired
+        onLeave: PropTypes.func.isRequired,
+        tracesConsidered: PropTypes.number.isRequired
     };
 
     // Get the midpoint between 2 points
@@ -70,11 +71,11 @@ export default class Lines extends Component {
         return '';
     };
 
-    // Helper function for calculating line opacity based on TPS
-    computeOpacity = (link) => {
-        const adjustedTps = link.tps ? link.tps - 15 : 0;
-        // Sigmoid function
-        return Math.max(adjustedTps / (1 + Math.abs(adjustedTps)), 0.2);
+    // Helper function for calculating line opacity based on count of traces for the link
+    computeOpacity = (link, tracesCount) => {
+        const adjustedCount = link.count || 0;
+
+        return Math.max(adjustedCount / tracesCount, 0.2);
     };
 
     // Capture mouse x,y values and call the onHover prop
@@ -85,7 +86,7 @@ export default class Lines extends Component {
     }
 
     render() {
-        const {edges, onLeave} = this.props;
+        const {edges, onLeave, tracesConsidered} = this.props;
 
         return (
             <g className="lines">
@@ -100,7 +101,7 @@ export default class Lines extends Component {
                             key={pathData.toString().replace(/\s/g, '')}
                             className={`line ${violationClass}`}
                             d={pathData}
-                            strokeOpacity={this.computeOpacity(edge.link)}
+                            strokeOpacity={this.computeOpacity(edge.link, tracesConsidered)}
                             onMouseOver={this.handleHover(edge.link)}
                             onMouseOut={onLeave}
                             onFocus={this.handleHover(edge.link)}

--- a/src/components/serviceInsights/serviceInsightsGraph/serviceInsightsGraph.jsx
+++ b/src/components/serviceInsights/serviceInsightsGraph/serviceInsightsGraph.jsx
@@ -67,6 +67,9 @@ export default class ServiceInsightsGraph extends Component {
     };
 
     render() {
+        const {
+            summary: {tracesConsidered}
+        } = this.props.graphData;
         const {nodes, edges} = buildGraphLayout(this.props.graphData);
         const graphSize = computeGraphSize(nodes);
         this.graphPos = computeGraphPosition(graphSize);
@@ -83,7 +86,7 @@ export default class ServiceInsightsGraph extends Component {
                     height={Math.max(graphSize.height + paddingBtm, minHeight)}
                 >
                     <DragGroup offsetX={this.graphPos.x} offsetY={this.graphPos.y}>
-                        <Lines edges={edges} onHover={this.handleLineHover} onLeave={this.handleLeave} />
+                        <Lines edges={edges} onHover={this.handleLineHover} onLeave={this.handleLeave} tracesConsidered={tracesConsidered} />
                         <Nodes nodes={nodes} onHover={this.handleNodeHover} onLeave={this.handleLeave} />
                         <Labels nodes={nodes} />
                     </DragGroup>

--- a/src/components/serviceInsights/summary.jsx
+++ b/src/components/serviceInsights/summary.jsx
@@ -21,7 +21,9 @@ import PropTypes from 'prop-types';
 function Summary({data}) {
     return (
         <div className="header-summary">
-            <div>Traces considered: {data.tracesConsidered}</div>
+            <div>
+                Traces considered: {data.tracesConsidered} {data.traceLimitReached ? '(limit reached)' : ''}
+            </div>
             {data.hasViolations && (
                 <div className="violation-grid">
                     <div className="violation-title">Violations found: </div>

--- a/test/src/components/serviceInsights/serviceInsightsGraph/lines.spec.jsx
+++ b/test/src/components/serviceInsights/serviceInsightsGraph/lines.spec.jsx
@@ -45,20 +45,20 @@ describe('<Lines/>', () => {
     });
 
     it('should render with high opacity on edges with high tps', () => {
-        const edges = [{link: {tps: 100}}];
-        const wrapper = shallow(<Lines edges={edges} onHover={() => {}} onLeave={() => {}} />);
+        const edges = [{link: {count: 100}}];
+        const wrapper = shallow(<Lines edges={edges} onHover={() => {}} onLeave={() => {}} tracesConsidered={100} />);
         expect(wrapper.find('.line').prop('strokeOpacity')).to.greaterThan(0.9);
     });
 
     it('should render with low opacity on edges with low tps', () => {
-        const edges = [{link: {tps: 1}}];
-        const wrapper = shallow(<Lines edges={edges} onHover={() => {}} onLeave={() => {}} />);
+        const edges = [{link: {count: 1}}];
+        const wrapper = shallow(<Lines edges={edges} onHover={() => {}} onLeave={() => {}} tracesConsidered={100} />);
         expect(wrapper.find('.line').prop('strokeOpacity')).to.equal(0.2);
     });
 
     it('should render with a default opacity of `0.2` on edges with no tps', () => {
         const edges = [{link: {}}];
-        const wrapper = shallow(<Lines edges={edges} onHover={() => {}} onLeave={() => {}} />);
+        const wrapper = shallow(<Lines edges={edges} onHover={() => {}} onLeave={() => {}} tracesConsidered={100} />);
         expect(wrapper.find('.line').prop('strokeOpacity')).to.equal(0.2);
     });
 
@@ -69,7 +69,7 @@ describe('<Lines/>', () => {
                 link: {tps: 20}
             }
         ];
-        const wrapper = shallow(<Lines edges={edges} onHover={() => {}} onLeave={() => {}} />);
+        const wrapper = shallow(<Lines edges={edges} onHover={() => {}} onLeave={() => {}} tracesConsidered={100} />);
         expect(
             wrapper
                 .find('.line')
@@ -82,7 +82,7 @@ describe('<Lines/>', () => {
     it('should call onHover event with x, y, and link data', () => {
         const hoverStub = sinon.stub();
         const edges = [{link: {tps: 1}}];
-        const wrapper = shallow(<Lines edges={edges} onHover={hoverStub} onLeave={() => {}} />);
+        const wrapper = shallow(<Lines edges={edges} onHover={hoverStub} onLeave={() => {}} tracesConsidered={100} />);
 
         wrapper.find('.line').simulate('mouseover', {clientX: 4, clientY: 5});
 
@@ -92,7 +92,7 @@ describe('<Lines/>', () => {
     it('should call onLeave event', () => {
         const leaveStub = sinon.stub();
         const edges = [{link: {tps: 1}}];
-        const wrapper = shallow(<Lines edges={edges} onHover={() => {}} onLeave={leaveStub} />);
+        const wrapper = shallow(<Lines edges={edges} onHover={() => {}} onLeave={leaveStub} tracesConsidered={100} />);
 
         wrapper.find('.line').simulate('mouseout');
 

--- a/test/src/components/serviceInsights/serviceInsightsGraph/serviceInsightsGraph.spec.jsx
+++ b/test/src/components/serviceInsights/serviceInsightsGraph/serviceInsightsGraph.spec.jsx
@@ -26,7 +26,7 @@ import ServiceInsightsGraph from '../../../../../src/components/serviceInsights/
 
 describe('<ServiceInsightsGraph/>', () => {
     it('should render the expected elements', () => {
-        const graphData = {nodes: [], links: []};
+        const graphData = {nodes: [], links: [], summary: {tracesConsidered: 0, traceLimitReached: false}};
         const wrapper = shallow(<ServiceInsightsGraph graphData={graphData} />);
 
         expect(wrapper.find('.service-insights-graph')).to.have.lengthOf(1);
@@ -40,7 +40,7 @@ describe('<ServiceInsightsGraph/>', () => {
 
     it("should set the svg's width and height", () => {
         dataLayout.computeGraphSize = sinon.stub().returns({width: 640, height: 480});
-        const graphData = {nodes: [], links: []};
+        const graphData = {nodes: [], links: [], summary: {tracesConsidered: 0, traceLimitReached: false}};
         const wrapper = shallow(<ServiceInsightsGraph graphData={graphData} />);
 
         expect(wrapper.find('.service-insights-graph_svg').prop('width')).to.equal(840);
@@ -49,7 +49,7 @@ describe('<ServiceInsightsGraph/>', () => {
 
     it("should set the svg's height to no less than minimum", () => {
         dataLayout.computeGraphSize = sinon.stub().returns({width: 640, height: 200});
-        const graphData = {nodes: [], links: []};
+        const graphData = {nodes: [], links: [], summary: {tracesConsidered: 0, traceLimitReached: false}};
         const wrapper = shallow(<ServiceInsightsGraph graphData={graphData} />);
 
         expect(wrapper.find('.service-insights-graph_svg').prop('height')).to.equal(360);
@@ -57,7 +57,7 @@ describe('<ServiceInsightsGraph/>', () => {
 
     it("should set the DragGroup's offsets based on graphPosition values", () => {
         dataLayout.computeGraphPosition = sinon.stub().returns({x: 100, y: 80});
-        const graphData = {nodes: [], links: []};
+        const graphData = {nodes: [], links: [], summary: {tracesConsidered: 0, traceLimitReached: false}};
         const wrapper = shallow(<ServiceInsightsGraph graphData={graphData} />);
 
         expect(wrapper.find('DragGroup').prop('offsetX')).to.equal(100);
@@ -65,7 +65,7 @@ describe('<ServiceInsightsGraph/>', () => {
     });
 
     it("should set the Tooltip's props based on state values", () => {
-        const graphData = {nodes: [], links: []};
+        const graphData = {nodes: [], links: [], summary: {tracesConsidered: 0, traceLimitReached: false}};
         const wrapper = shallow(<ServiceInsightsGraph graphData={graphData} />);
 
         wrapper.setState({
@@ -83,7 +83,7 @@ describe('<ServiceInsightsGraph/>', () => {
     });
 
     it('should set state values when onNodeHover is called', () => {
-        const graphData = {nodes: [], links: []};
+        const graphData = {nodes: [], links: [], summary: {tracesConsidered: 0, traceLimitReached: false}};
         const instance = shallow(<ServiceInsightsGraph graphData={graphData} />).instance();
 
         instance.handleNodeHover({}, 7, 8, {foo: 'bar'});
@@ -95,7 +95,7 @@ describe('<ServiceInsightsGraph/>', () => {
     });
 
     it('should set state values when handleLineHover is called', () => {
-        const graphData = {nodes: [], links: []};
+        const graphData = {nodes: [], links: [], summary: {tracesConsidered: 0, traceLimitReached: false}};
         const instance = shallow(<ServiceInsightsGraph graphData={graphData} />).instance();
 
         instance.handleLineHover({}, 9, 10, {bar: 'baz'});
@@ -107,7 +107,7 @@ describe('<ServiceInsightsGraph/>', () => {
     });
 
     it('should set tipVisible to false when handleLeave is called', () => {
-        const graphData = {nodes: [], links: []};
+        const graphData = {nodes: [], links: [], summary: {tracesConsidered: 0, traceLimitReached: false}};
         const instance = shallow(<ServiceInsightsGraph graphData={graphData} />).instance();
 
         instance.state.tipVisible = true;

--- a/test/src/components/serviceInsights/summary.spec.jsx
+++ b/test/src/components/serviceInsights/summary.spec.jsx
@@ -23,7 +23,7 @@ import Summary from '../../../../src/components/serviceInsights/summary';
 
 describe('<Summary/>', () => {
     it('should render the expected elements', () => {
-        const data = {tracesConsidered: 5};
+        const data = {tracesConsidered: 5, traceLimitReached: false};
         const wrapper = shallow(<Summary data={data} />);
 
         expect(wrapper.find('.header-summary')).to.have.lengthOf(1);
@@ -34,6 +34,7 @@ describe('<Summary/>', () => {
         const data = {
             tracesConsidered: 5,
             hasViolations: true,
+            traceLimitReached: false,
             violations: {
                 'Uninstrumented services': 2
             }
@@ -42,5 +43,15 @@ describe('<Summary/>', () => {
 
         expect(wrapper.find('.violation-grid')).to.have.lengthOf(1);
         expect(wrapper.find('.violation-grid').text()).to.contain('Uninstrumented services (2)');
+    });
+
+    it('should render trace limit reached', () => {
+        const data = {
+            tracesConsidered: 5,
+            traceLimitReached: true
+        };
+        const wrapper = shallow(<Summary data={data} />);
+
+        expect(wrapper.find('.header-summary').text()).to.contain('(limit reached)');
     });
 });


### PR DESCRIPTION
Allowing more traces to be used for Service Insights (original PR #498).

Service Insights will allow a limit to be passed via its api but will default to the configurable limit. The Service Insights front-end is updated if that limit has been reached.

![Screen Shot 2019-08-16 at 7 47 35 AM](https://user-images.githubusercontent.com/7073755/63168577-29787480-bffa-11e9-90c0-2fb7d906456e.png)
