### PR TITLE
Traces Proxy and Service Insights fixes

### DIFF
--- a/server/config/base.js
+++ b/server/config/base.js
@@ -51,7 +51,7 @@ module.exports = {
             // used by haystack-ui-proxy connector
             // proxy: {
             //     baseUrl: 'https://haystack.example.com',
-            //     cookie: 'YOUR_COOKIE_NAME=YOUR_COOKIE_VALUE'
+            //     cookie: 'YOUR_COOKIE_NAME=YOUR_COOKIE_VALUE;'
             // },
             // interval in seconds to refresh the service and operation data from backend
             serviceRefreshIntervalInSecs: 60

--- a/server/config/base.js
+++ b/server/config/base.js
@@ -51,8 +51,7 @@ module.exports = {
             // used by haystack-ui-proxy connector
             // proxy: {
             //     baseUrl: 'https://haystack.example.com',
-            //     cookieName: 'SESSION_COOKIE',
-            //     cookieValue: '' // use environment variable HAYSTACK_PROP_CONNECTORS_TRACES_PROXY_COOKIE__VALUE=your-cookie-value
+            //     cookie: 'YOUR_COOKIE_NAME=YOUR_COOKIE_VALUE'
             // },
             // interval in seconds to refresh the service and operation data from backend
             serviceRefreshIntervalInSecs: 60

--- a/server/connectors/serviceInsights/graphDataExtractor.js
+++ b/server/connectors/serviceInsights/graphDataExtractor.js
@@ -193,7 +193,7 @@ function findViolations(nodes, links) {
     // Store count of uninstrumented
     const uninstrumentedCount = [...nodes.values()]
         .map((node) => (node.type === type.uninstrumented ? 1 : 0))
-        .reduce((count, current) => count + current);
+        .reduce((count, current) => count + current, 0);
 
     // Summarize unique count of uninstrumented dependencies
     if (uninstrumentedCount > 0) {
@@ -235,8 +235,10 @@ function processNodesAndLinks(nodes, links, relationshipFilter) {
 
     // Traverse nodes upstream and downstream of the central node and set their relationship
     const centralNode = [...nodes.values()].find((node) => node.relationship === relationship.central);
-    traverseDownstream(centralNode);
-    traverseUpstream(centralNode);
+    if (centralNode) {
+        traverseDownstream(centralNode);
+        traverseUpstream(centralNode);
+    }
 
     // Process nodes
     nodes.forEach((node) => {

--- a/server/connectors/traces/haystack-ui-proxy/tracesConnector.js
+++ b/server/connectors/traces/haystack-ui-proxy/tracesConnector.js
@@ -20,7 +20,7 @@ const _ = require('lodash');
 const config = require('../../../config/config');
 const fetcher = require('../../operations/restFetcher');
 
-const {baseUrl, cookieName, cookieValue} = config.connectors.traces.proxy;
+const {baseUrl, cookie} = config.connectors.traces.proxy;
 
 const connector = {};
 
@@ -79,7 +79,7 @@ connector.getRawTraces = (traceIdsString) => {
     traceIds.forEach((traceId) => {
         promisedSpans.push(
             fetcher('getRawTraces').fetch(`${baseUrl}/api/trace/${traceId}`, {
-                Cookie: `${cookieName}=${cookieValue}`
+                Cookie: `${cookie}`
             })
         );
     });
@@ -90,7 +90,7 @@ connector.findTraces = ({serviceName, startTime, endTime}) =>
     Q.fcall(() =>
         fetcher('findTraces')
             .fetch(`${baseUrl}/api/traces?useExpressionTree=true&serviceName=${serviceName}&startTime=${startTime}&endTime=${endTime}`, {
-                Cookie: `${cookieName}=${cookieValue}`
+                Cookie: `${cookie}`
             })
             .then((traces) => {
                 if (!Array.isArray(traces)) {

--- a/server/connectors/traces/haystack-ui-proxy/tracesConnector.js
+++ b/server/connectors/traces/haystack-ui-proxy/tracesConnector.js
@@ -73,18 +73,12 @@ connector.getRawSpan = () =>
         throw new Error('Unsupported by haystack-ui-proxy connector.');
     });
 
-connector.getRawTraces = (traceIdsString) => {
-    const traceIds = JSON.parse(traceIdsString);
-    const promisedSpans = [];
-    traceIds.forEach((traceId) => {
-        promisedSpans.push(
-            fetcher('getRawTraces').fetch(`${baseUrl}/api/trace/${traceId}`, {
-                Cookie: `${cookie}`
-            })
-        );
-    });
-    return Q.all(promisedSpans).then((spans) => [].concat(...spans));
-};
+connector.getRawTraces = (traceIdsString) =>
+    Q.fcall(() =>
+        fetcher('getRawTraces').fetch(`${baseUrl}/api/traces/raw?traceIds=${traceIdsString}`, {
+            Cookie: `${cookie}`
+        })
+    );
 
 connector.findTraces = ({serviceName, startTime, endTime}) =>
     Q.fcall(() =>

--- a/test/server/connectors/serviceInsights/graphDataExtractor.spec.js
+++ b/test/server/connectors/serviceInsights/graphDataExtractor.spec.js
@@ -265,6 +265,19 @@ describe('graphDataExtractor.extractNodesAndLinks', () => {
         expect(links.find((e) => e.source === 'some-ui-app')).to.have.property('count', 1);
     });
 
+    it('should gracefully handle an empty array of spans', () => {
+        // given
+        const spans = [];
+
+        // when
+        const {summary, nodes, links} = extractNodesAndLinks({spans, serviceName: 'some-ui-app', traceLimitReached: false});
+
+        // then
+        expect(summary).to.have.property('tracesConsidered', 0);
+        expect(nodes).to.be.an('array').that.is.empty;
+        expect(links).to.be.an('array').that.is.empty;
+    });
+
     it('should gracefully handle missing parent spans', () => {
         // given
         const spans = trace(uiAppSpan());


### PR DESCRIPTION
Traces proxy:
- Changes the cookie configuration for `haystack-ui-proxy` from a name/value pair to a single string. This format is more convenient when more than one cookie is required.
- Fixes the `getRawTraces` function in the proxy connector to correctly call the `/api/traces/raw` endpoint. Previously it was iterating over the `/api/trace/` endpoint for each trace which was both inefficient and incorrect.

Service Insights:
- Adds handling of an empty array of spans, such as when the search gives no results. Previously an empty array caused errors in the logs.
