### PR TITLE
handle empty array of spans

### DIFF
--- a/server/connectors/serviceInsights/graphDataExtractor.js
+++ b/server/connectors/serviceInsights/graphDataExtractor.js
@@ -203,7 +203,7 @@ function findViolations(nodes, links) {
     // Store count of uninstrumented
     const uninstrumentedCount = [...nodes.values()]
         .map((node) => (node.type === type.uninstrumented ? 1 : 0))
-        .reduce((count, current) => count + current);
+        .reduce((count, current) => count + current, 0);
 
     // Summarize unique count of uninstrumented dependencies
     if (uninstrumentedCount > 0) {
@@ -245,8 +245,10 @@ function processNodesAndLinks(nodes, links, relationshipFilter) {
 
     // Traverse nodes upstream and downstream of the central node and set their relationship
     const centralNode = [...nodes.values()].find((node) => node.relationship === relationship.central);
-    traverseDownstream(centralNode);
-    traverseUpstream(centralNode);
+    if (centralNode) {
+        traverseDownstream(centralNode);
+        traverseUpstream(centralNode);
+    }
 
     // Process nodes
     nodes.forEach((node) => {

--- a/test/server/connectors/serviceInsights/graphDataExtractor.spec.js
+++ b/test/server/connectors/serviceInsights/graphDataExtractor.spec.js
@@ -270,6 +270,19 @@ describe('graphDataExtractor.extractNodesAndLinks', () => {
         expect(links.find((e) => e.source === 'some-ui-app')).to.have.property('count', 1);
     });
 
+    it('should gracefully handle an empty array of spans', () => {
+        // given
+        const spans = [];
+
+        // when
+        const {summary, nodes, links} = extractNodesAndLinks({spans, serviceName: 'some-ui-app', traceLimitReached: false});
+
+        // then
+        expect(summary).to.have.property('tracesConsidered', 0);
+        expect(nodes).to.be.an('array').that.is.empty;
+        expect(links).to.be.an('array').that.is.empty;
+    });
+
     it('should gracefully handle missing parent spans', () => {
         // given
         const spans = trace(uiAppSpan());


### PR DESCRIPTION
Adds handling of an empty array of spans, such as when the search gives no results. Previously an empty array caused errors in the logs.