### PR TITLE
Address a few tab bugs

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -90,12 +90,16 @@ if (config.enableSSO) {
 
 const apis = [];
 if (config.connectors.traces && config.connectors.traces.connectorName !== 'disabled') apis.push(require('./routes/servicesApi'));
-if (config.connectors.traces && config.connectors.traces.connectorName !== 'disabled') apis.push(require('./routes/tracesApi'));
+
+if (config.connectors.traces && config.connectors.traces.connectorName !== 'disabled') {
+    apis.push(require('./routes/tracesApi'));
+    apis.push(require('./routes/serviceInsightsApi'));
+}
+
 if (config.connectors.trends && config.connectors.trends.connectorName !== 'disabled') apis.push(require('./routes/trendsApi'));
 if (config.connectors.trends && config.connectors.trends.connectorName !== 'disabled') apis.push(require('./routes/servicesPerfApi'));
 if (config.connectors.alerts && config.connectors.alerts.connectorName !== 'disabled') apis.push(require('./routes/alertsApi'));
 if (config.connectors.serviceGraph && config.connectors.serviceGraph.connectorName !== 'disabled') apis.push(require('./routes/serviceGraphApi'));
-if (config.connectors.serviceInsights && config.connectors.serviceInsights.enableServiceInsights) apis.push(require('./routes/serviceInsightsApi'));
 
 app.use('/api', ...apis);
 

--- a/src/components/universalSearch/searchBar/stores/searchBarUiStateStore.js
+++ b/src/components/universalSearch/searchBar/stores/searchBarUiStateStore.js
@@ -88,7 +88,8 @@ export class SearchBarUiStateStore {
         // construct current search object using observables
         const search = SearchBarUiStateStore.turnChipsIntoSearch(this.chips);
 
-        const showAllTabs = Object.keys(search).every((key) => key === 'serviceName' || key === 'operationName');
+        const showAllTabs = Object.keys(search).every((key) => key === 'serviceName' || key === 'operationName') || this.tabId === 'serviceInsights';
+
         if (this.tabId && showAllTabs) {
             search.tabId = this.tabId;
         }

--- a/src/components/universalSearch/tabs/tabStores/serviceInsightsTabStateStore.js
+++ b/src/components/universalSearch/tabs/tabStores/serviceInsightsTabStateStore.js
@@ -27,8 +27,11 @@ export class ServiceInsightsTabStateStore {
     init(search) {
         this.search = search;
 
+        // If user is directly accessing URL, show this feature
+        const isAccessingServiceInsights = this.search.tabId === 'serviceInsights';
+
         // TODO: reconcile this with hasValidSearchProps() in serviceInsights.jsx
-        this.isAvailable = !!(subsystems && enableServiceInsights && search.serviceName);
+        this.isAvailable = isAccessingServiceInsights || !!(subsystems && enableServiceInsights && search.serviceName);
     }
 
     fetch() {

--- a/src/components/universalSearch/tabs/tabStores/tracesTabStateStore.js
+++ b/src/components/universalSearch/tabs/tabStores/tracesTabStateStore.js
@@ -19,7 +19,7 @@ const subsystems = (window.haystackUiConfig && window.haystackUiConfig.subsystem
 const enabled = subsystems.includes('traces');
 
 function spanLevelFiltersToList(filteredNames, traceSearch) {
-    return JSON.stringify(filteredNames.map(name => JSON.stringify(traceSearch[name])));
+    return JSON.stringify(filteredNames.map((name) => JSON.stringify(traceSearch[name])));
 }
 
 export class TracesTabStateStore {
@@ -33,17 +33,18 @@ export class TracesTabStateStore {
 
         // check all keys except time
         // eslint-disable-next-line no-unused-vars
-        const {time, tabId, type, ...kv} =  search;
-        this.isAvailable = enabled && !!Object.keys(kv).length;
+        const {time, tabId, type, ...kv} = search;
+        const isAccessingTraces = search.tabId === 'traces';
+        this.isAvailable = isAccessingTraces || (enabled && !!Object.keys(kv).length);
     }
 
     fetch() {
         // TODO acting as a wrapper for older stores for now,
         // TODO fetch logic here
         // eslint-disable-next-line no-unused-vars
-        const { time, tabId, type, interval, serviceName, ...traceSearch } = this.search;
+        const {time, tabId, type, interval, serviceName, ...traceSearch} = this.search;
 
-        const filteredNames = Object.keys(traceSearch).filter(name => /nested_[0-9]/.test(name));
+        const filteredNames = Object.keys(traceSearch).filter((name) => /nested_[0-9]/.test(name));
 
         traceSearch.useExpressionTree = true;
         traceSearch.spanLevelFilters = spanLevelFiltersToList(filteredNames, traceSearch);

--- a/test/server/routes/serviceInsightsApi.spec.js
+++ b/test/server/routes/serviceInsightsApi.spec.js
@@ -13,14 +13,18 @@
  *         See the License for the specific language governing permissions and
  *         limitations under the License.
  */
+/* 
 
-const server = require('../../../server/app.js');
+
 const request = require('supertest');
+*/
 
 describe('routes.servicesApi', () => {
     it('returns http 200 for /api/serviceInsights', (done) => {
+        done();
+        /*
         request(server)
-            .get('/api/serviceInsights?serviceName=mock-ui&from=1000&to=2000')
+            .get('/api/serviceInsights?serviceName=stark-service&from=1000&to=2000')
             .expect(200)
             .end((err) => {
                 if (err) {
@@ -28,5 +32,6 @@ describe('routes.servicesApi', () => {
                 }
                 return done();
             });
+        */
     });
 });

--- a/test/server/routes/serviceInsightsApi.spec.js
+++ b/test/server/routes/serviceInsightsApi.spec.js
@@ -13,16 +13,12 @@
  *         See the License for the specific language governing permissions and
  *         limitations under the License.
  */
-/* 
 
-
+const server = require('../../../server/app.js');
 const request = require('supertest');
-*/
 
 describe('routes.servicesApi', () => {
     it('returns http 200 for /api/serviceInsights', (done) => {
-        done();
-        /*
         request(server)
             .get('/api/serviceInsights?serviceName=stark-service&from=1000&to=2000')
             .expect(200)
@@ -32,6 +28,5 @@ describe('routes.servicesApi', () => {
                 }
                 return done();
             });
-        */
     });
 });

--- a/test/src/components/universalSearch/searchBar/stores/searchBarUiStateStore.spec.js
+++ b/test/src/components/universalSearch/searchBar/stores/searchBarUiStateStore.spec.js
@@ -43,6 +43,13 @@ describe('class SearchBarUiStateStore()', () => {
         });
     });
 
+    it('setOperatorFromValue() returns operator from KV pair', () => {
+        expect(SearchBarUiStateStore.setOperatorFromValue(['<'])).to.equal('<');
+        expect(SearchBarUiStateStore.setOperatorFromValue(['>'])).to.equal('>');
+        expect(SearchBarUiStateStore.setOperatorFromValue(['='])).to.equal('=');
+        expect(SearchBarUiStateStore.setOperatorFromValue([false])).to.equal('=');
+    });
+
     it('properly processes chips', () => {
         const chips = [
             {

--- a/test/src/components/universalSearch/searchBar/stores/searchBarUiStateStore.spec.js
+++ b/test/src/components/universalSearch/searchBar/stores/searchBarUiStateStore.spec.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 Expedia Group
+ *
+ *       Licensed under the Apache License, Version 2.0 (the 'License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+
+import {expect} from 'chai';
+
+const {SearchBarUiStateStore} = require('../../../../../../src/components/universalSearch/searchBar/stores/searchBarUiStateStore.js');
+
+describe('class SearchBarUiStateStore()', () => {
+    const mockSearch = {
+        tabId: 'traces',
+        time: {
+            to: 2,
+            from: 1
+        }
+    };
+    let MockSearchBarUiStateStore;
+    beforeEach(() => {
+        MockSearchBarUiStateStore = new SearchBarUiStateStore();
+        MockSearchBarUiStateStore.init(mockSearch);
+    });
+    it('initializes store properly', () => {
+        MockSearchBarUiStateStore.init(mockSearch);
+        expect(MockSearchBarUiStateStore.getCurrentSearch()).to.deep.equal({
+            tabId: 'traces',
+            time: {
+                from: 1,
+                to: 2
+            }
+        });
+    });
+
+    it('properly processes chips', () => {
+        const chips = [
+            {
+                key: 'foo',
+                operator: '=',
+                value: 'bar'
+            },
+            {
+                key: 'nested_foo',
+                operator: '>',
+                value: [
+                    {
+                        key: 'foo_sub',
+                        operator: '=',
+                        value: 'bar_sub'
+                    }
+                ]
+            }
+        ];
+        const result = SearchBarUiStateStore.turnChipsIntoSearch(chips);
+        expect(result).to.deep.equal({
+            foo: 'bar',
+            nested_foo: {
+                foo_sub: 'bar_sub'
+            }
+        });
+    });
+});

--- a/test/src/components/universalSearch/tabs/tabStores/tracesTabStateStore.spec.js
+++ b/test/src/components/universalSearch/tabs/tabStores/tracesTabStateStore.spec.js
@@ -17,8 +17,8 @@
 
 import {expect} from 'chai';
 
-describe('class ServiceInsightsTabStateStore()', () => {
-    const modulePath = '../../../../../../src/components/universalSearch/tabs/tabStores/serviceInsightsTabStateStore';
+describe('<Traces />', () => {
+    const modulePath = '../../../../../../src/components/universalSearch/tabs/tabStores/tracesTabStateStore.js';
     let oldHaystackUiConfig = null;
     beforeEach(() => {
         // clear require cache
@@ -33,33 +33,13 @@ describe('class ServiceInsightsTabStateStore()', () => {
         let store = require(modulePath).default; // eslint-disable-line
         expect(store.isAvailable).to.equal(false);
     });
-    it('should initialize `isAvailable` as true if `enableServiceInsights` is enabled and search contains `serviceName`', () => {
-        window.haystackUiConfig = {
-            enableServiceInsights: true
-        };
 
+    it('should initialize `isAvailable` as true when accessing traces', () => {
+        window.haystackUiConfig = {};
         let store = require(modulePath).default; // eslint-disable-line
         store.init({
-            serviceName: 'mock-ui'
+            tabId: 'traces'
         });
         expect(store.isAvailable).to.equal(true);
-    });
-    it('should set `isAvailable` as true if `tabId` is set to `serviceInsights`', () => {
-        window.haystackUiConfig = {
-            enableServiceInsights: false
-        };
-        let store = require(modulePath).default; // eslint-disable-line
-        store.init({
-            tabId: 'serviceInsights',
-            serviceName: 'mock-ui'
-        });
-        expect(store.isAvailable).to.equal(true);
-    });
-    it('should return a valid serviceInsights store from fetch()', () => {
-        window.haystackUiConfig = {
-            enableServiceInsights: true
-        };
-        let store = require(modulePath).default; // eslint-disable-line
-        expect(JSON.stringify(store.fetch().serviceInsights)).to.equal('{}');
     });
 });


### PR DESCRIPTION
# Overview

This PR addresses a few minor bugs that are related to the display of tabs when accessing service insights and traces.  The effect of these changes are:

- When accessing service insights directly, render service insights tab focused
- While using service insights, when searching for a traceId, stay focused on service insights
- While accessing traces without a defined serviceName, render traces tab