### PR TITLE
Service Insights support for operationName and traceId

### DIFF
--- a/server/connectors/serviceInsights/fetcher.js
+++ b/server/connectors/serviceInsights/fetcher.js
@@ -26,19 +26,23 @@ const metrics = require('../../utils/metrics');
 const TRACE_LIMIT = config.connectors.serviceInsights.traceLimit;
 
 const fetcher = (fetcherName) => ({
-    fetch(serviceName, startTime, endTime, limit) {
+    fetch(options) {
+        const {serviceName, operationName, traceId, startTime, endTime} = options;
+
         // local vars
         const deferred = Q.defer();
         const timer = metrics.timer(`fetcher_${fetcherName}`).start();
 
         // use given limit or default
-        limit = limit || TRACE_LIMIT;
+        const limit = options.limit || TRACE_LIMIT;
 
         // use traces connector
         tracesConnector
             .findTracesFlat({
                 useExpressionTree: 'true',
                 serviceName,
+                operationName,
+                traceId,
                 startTime,
                 endTime,
                 limit,

--- a/server/connectors/serviceInsights/serviceInsightsConnector.js
+++ b/server/connectors/serviceInsights/serviceInsightsConnector.js
@@ -21,14 +21,26 @@ const extractor = require('./graphDataExtractor');
 
 const connector = {};
 
-function fetchServiceInsights(serviceName, startTime, endTime, limit, relationship) {
+function fetchServiceInsights(options) {
+    const {serviceName, operationName, traceId, startTime, endTime, limit, relationship} = options;
     const relationshipFilter = relationship ? relationship.split(',') : [];
     return fetcher(serviceName)
-        .fetch(serviceName, startTime, endTime, limit)
+        .fetch({serviceName, operationName, traceId, startTime, endTime, limit})
         .then((data) => extractor.extractNodesAndLinks(data, relationshipFilter));
 }
 
-connector.getServiceInsightsForService = (serviceName, startTime, endTime, limit, relationship) =>
-    Q.fcall(() => fetchServiceInsights(serviceName, startTime, endTime, limit, relationship));
+/**
+ * getServiceInsightsForService
+ *
+ * @param {object} options - Object with the following options:
+ * - serviceName - service to get Service Insights for (required, unless traceId is provided)
+ * - operationName - operation to filter for (optional)
+ * - traceId - single trace to get Service Insights for (optional)
+ * - startTime - filter for traces after this time in microseconds (required)
+ * - endTime - filter for traces before this time in microseconds (required)
+ * - limit - override the default config limit on number of traces to fetch (optional)
+ * - relationship - comma-separated list of relationships to include (optional)
+ */
+connector.getServiceInsightsForService = (options) => Q.fcall(() => fetchServiceInsights(options));
 
 module.exports = connector;

--- a/server/connectors/traces/haystack/search/searchRequestBuilder.js
+++ b/server/connectors/traces/haystack/search/searchRequestBuilder.js
@@ -24,8 +24,8 @@ const DEFAULT_RESULTS_LIMIT = 25;
 
 function createFieldsList(query) {
     return Object.keys(query)
-    .filter(key => query[key] && !reservedField.includes(key))
-    .map(key => expressionTreeBuilder(key, query[key]));
+        .filter((key) => query[key] && !reservedField.includes(key))
+        .map((key) => expressionTreeBuilder(key, query[key]));
 }
 
 requestBuilder.buildRequest = (query) => {

--- a/server/routes/serviceInsightsApi.js
+++ b/server/routes/serviceInsightsApi.js
@@ -23,8 +23,16 @@ const router = express.Router();
 
 router.get('/serviceInsights', (req, res, next) => {
     handleResponsePromise(res, next, 'svc_insights_SVC')(() => {
-        const {serviceName, startTime, endTime, limit, relationship} = req.query;
-        return serviceInsightsConnector.getServiceInsightsForService(serviceName, startTime, endTime, limit, relationship);
+        const {serviceName, operationName, traceId, startTime, endTime, limit, relationship} = req.query;
+        return serviceInsightsConnector.getServiceInsightsForService({
+            serviceName,
+            operationName,
+            traceId,
+            startTime,
+            endTime,
+            limit,
+            relationship
+        });
     });
 });
 

--- a/src/components/serviceInsights/stores/serviceInsightsStore.js
+++ b/src/components/serviceInsights/stores/serviceInsightsStore.js
@@ -25,13 +25,18 @@ export class ServiceInsightsStore extends ErrorHandlingStore {
     @observable filterQuery = null;
 
     @action fetchServiceInsights(filterQuery) {
-        const {serviceName, startTime, endTime, relationship} = filterQuery;
+        const {serviceName, operationName, traceId, startTime, endTime, relationship} = filterQuery;
 
+        // optional parameters
+        const operationNameParam = operationName ? `&operationName=${operationName}` : '';
+        const traceIdParam = traceId ? `&traceId=${traceId}` : '';
         const relationshipParam = relationship ? `&relationship=${relationship}` : '';
 
         this.promiseState = fromPromise(
             axios
-                .get(`/api/serviceInsights?serviceName=${serviceName}&startTime=${startTime}&endTime=${endTime}${relationshipParam}`)
+                .get(
+                    `/api/serviceInsights?serviceName=${serviceName}${operationNameParam}${traceIdParam}&startTime=${startTime}&endTime=${endTime}${relationshipParam}`
+                )
                 .then((result) => {
                     this.filterQuery = filterQuery;
                     this.serviceInsights = result.data;

--- a/src/components/universalSearch/tabs/tabStores/serviceInsightsTabStateStore.js
+++ b/src/components/universalSearch/tabs/tabStores/serviceInsightsTabStateStore.js
@@ -31,7 +31,8 @@ export class ServiceInsightsTabStateStore {
         const isAccessingServiceInsights = this.search.tabId === 'serviceInsights';
 
         // TODO: reconcile this with hasValidSearchProps() in serviceInsights.jsx
-        this.isAvailable = isAccessingServiceInsights || !!(subsystems && enableServiceInsights && search.serviceName);
+        const validSearchProps = search.serviceName || search.traceId;
+        this.isAvailable = isAccessingServiceInsights || !!(subsystems && enableServiceInsights && validSearchProps);
     }
 
     fetch() {

--- a/test/server/connectors/serviceInsights/fetcher.spec.js
+++ b/test/server/connectors/serviceInsights/fetcher.spec.js
@@ -15,6 +15,8 @@
  *
  */
 
+/* eslint-disable no-unused-expressions */
+
 import {expect} from 'chai';
 
 const sinon = require('sinon');
@@ -23,7 +25,6 @@ const proxyquire = require('proxyquire');
 // Mock trace data
 // Initialized in `beforeEach()` during unit test
 let mockTraces = null;
-let mockRawTraces = null;
 
 // Create mock logger
 const logger = sinon.spy();
@@ -66,7 +67,6 @@ const fetcher = proxyquire('../../../../server/connectors/serviceInsights/fetche
 describe('fetcher.fetch', () => {
     beforeEach(() => {
         mockTraces = [];
-        mockRawTraces = [];
         metricsTimerSpy.reset();
         metricsStartSpy.reset();
         metricsStopSpy.reset();
@@ -76,9 +76,14 @@ describe('fetcher.fetch', () => {
     it('should return 0 spans given 0 traces', (done) => {
         // given
         const {fetch} = fetcher('service_insights');
+        const options = {
+            serviceName: 'mock-service',
+            startTime: '1000',
+            endTime: '2000'
+        };
 
         // when
-        fetch('mock-service', '1000', '2000')
+        fetch(options)
             .then((result) => {
                 // then
                 expect(result.serviceName).to.equal('mock-service');
@@ -94,9 +99,14 @@ describe('fetcher.fetch', () => {
         // given
         mockTraces = false;
         const {fetch} = fetcher('service_insights');
+        const options = {
+            serviceName: 'mock-service',
+            startTime: '1000',
+            endTime: '2000'
+        };
 
         // when
-        fetch('mock-service', '1000', '2000')
+        fetch(options)
             .then((result) => {
                 // then
                 expect(result.serviceName).to.equal('mock-service');
@@ -116,9 +126,15 @@ describe('fetcher.fetch', () => {
             }
         ];
         const {fetch} = fetcher('service insights');
+        const options = {
+            serviceName: 'mock-service',
+            startTime: '1000',
+            endTime: '2000',
+            limit: 1
+        };
 
         // when
-        fetch('mock-service', '1000', '2000', 1)
+        fetch(options)
             .then((result) => {
                 // then
                 expect(result.serviceName).to.equal('mock-service');

--- a/test/server/connectors/serviceInsights/serviceInsightsConnector.spec.js
+++ b/test/server/connectors/serviceInsights/serviceInsightsConnector.spec.js
@@ -49,9 +49,16 @@ const connector = proxyquire('../../../../server/connectors/serviceInsights/serv
 
 describe('serviceInsightsConnector.getServiceInsightsForService', () => {
     it('should initialize promise and return data', (done) => {
-        // given, when
+        // given
+        const options = {
+            serviceName: 'mock-service',
+            startTime: 1000,
+            endTime: 2000
+        };
+
+        // when
         connector
-            .getServiceInsightsForService('mock-service', 1000, 2000)
+            .getServiceInsightsForService(options)
             .then((result) => {
                 // then
                 expect(result).to.have.nested.property('summary.tracesConsidered', 1);
@@ -64,9 +71,17 @@ describe('serviceInsightsConnector.getServiceInsightsForService', () => {
     });
 
     it('should support relationships to filter', (done) => {
-        // given, when
+        // given
+        const options = {
+            serviceName: 'mock-service',
+            startTime: 1000,
+            endTime: 2000,
+            relationship: 'upstream'
+        };
+
+        // when
         connector
-            .getServiceInsightsForService('mock-service', 1000, 2000, 10, 'upstream')
+            .getServiceInsightsForService(options)
             .then((result) => {
                 // then
                 expect(result)

--- a/test/src/components/serviceInsights/serviceInsights.spec.jsx
+++ b/test/src/components/serviceInsights/serviceInsights.spec.jsx
@@ -66,6 +66,30 @@ describe('<ServiceInsights/>', () => {
             expect(wrapper.find('Summary')).to.have.lengthOf(1);
             expect(wrapper.find('ServiceInsightsGraph')).to.have.lengthOf(1);
         });
+
+        it('should render relationship filter when it’s applicable', () => {
+            const store = createStoreStub('fulfilled', {
+                summary: {tracesConsidered: 5},
+                nodes: [{}],
+                links: []
+            });
+
+            const wrapper = shallow(<ServiceInsights search={{serviceName: 'web-ui'}} store={store} />);
+
+            expect(wrapper.find('.service-insights__filter')).to.have.lengthOf(1);
+        });
+
+        it('should not render relationship filter when it’s not applicable', () => {
+            const store = createStoreStub('fulfilled', {
+                summary: {tracesConsidered: 1},
+                nodes: [{}],
+                links: []
+            });
+
+            const wrapper = shallow(<ServiceInsights search={{traceId: 'abc123'}} store={store} />);
+
+            expect(wrapper.find('.service-insights__filter')).to.have.lengthOf(0);
+        });
     });
 
     describe('getServiceInsight()', () => {

--- a/test/src/components/serviceInsights/stores/serviceInsightsStore.spec.js
+++ b/test/src/components/serviceInsights/stores/serviceInsightsStore.spec.js
@@ -83,20 +83,24 @@ describe('serviceInsightsStore', () => {
         });
     });
 
-    it('should support an optional relationship parameter', (done) => {
+    it('should support optional parameters', (done) => {
         // given, when
         store.fetchServiceInsights({
             serviceName: 'node-web-ui',
             startTime: 1000,
             endTime: 2000,
-            relationship: 'all'
+            relationship: 'all',
+            operationName: 'some-operation',
+            traceId: 'some-trace'
         });
         observe(store.promiseState, () => {
             store.promiseState.case({
                 fulfilled: (result) => {
                     // then
                     expect(
-                        mockAxiosSpy.calledWith('/api/serviceInsights?serviceName=node-web-ui&startTime=1000&endTime=2000&relationship=all')
+                        mockAxiosSpy.calledWith(
+                            '/api/serviceInsights?serviceName=node-web-ui&operationName=some-operation&traceId=some-trace&startTime=1000&endTime=2000&relationship=all'
+                        )
                     ).to.equal(true);
                     expect(result.data.summary.violations).to.equal(1);
                     done();


### PR DESCRIPTION
Adds support to Service Insights for:
- searching by `operationName` to filter for the given operation
- searching by `traceId` to show only a single trace

Normally `serviceName` is required for Service Insights, this change makes it optional when `traceId` is provided. When `serviceName` is omitted, upstream and downstream relationships are no longer meaningful, so the relationship filter is hidden and not applied.