### PR TITLE
Prevent app failure if SI configuration not present

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -90,16 +90,13 @@ if (config.enableSSO) {
 
 const apis = [];
 if (config.connectors.traces && config.connectors.traces.connectorName !== 'disabled') apis.push(require('./routes/servicesApi'));
-
-if (config.connectors.traces && config.connectors.traces.connectorName !== 'disabled') {
-    apis.push(require('./routes/tracesApi'));
-    apis.push(require('./routes/serviceInsightsApi'));
-}
-
+if (config.connectors.traces && config.connectors.traces.connectorName !== 'disabled') apis.push(require('./routes/tracesApi'));
 if (config.connectors.trends && config.connectors.trends.connectorName !== 'disabled') apis.push(require('./routes/trendsApi'));
 if (config.connectors.trends && config.connectors.trends.connectorName !== 'disabled') apis.push(require('./routes/servicesPerfApi'));
 if (config.connectors.alerts && config.connectors.alerts.connectorName !== 'disabled') apis.push(require('./routes/alertsApi'));
 if (config.connectors.serviceGraph && config.connectors.serviceGraph.connectorName !== 'disabled') apis.push(require('./routes/serviceGraphApi'));
+if (config.connectors.serviceInsights && config.connectors.serviceInsights.enableServiceInsights !== 'disabled')
+    apis.push(require('./routes/serviceInsightsApi'));
 
 app.use('/api', ...apis);
 

--- a/server/app.js
+++ b/server/app.js
@@ -95,8 +95,8 @@ if (config.connectors.trends && config.connectors.trends.connectorName !== 'disa
 if (config.connectors.trends && config.connectors.trends.connectorName !== 'disabled') apis.push(require('./routes/servicesPerfApi'));
 if (config.connectors.alerts && config.connectors.alerts.connectorName !== 'disabled') apis.push(require('./routes/alertsApi'));
 if (config.connectors.serviceGraph && config.connectors.serviceGraph.connectorName !== 'disabled') apis.push(require('./routes/serviceGraphApi'));
-if (config.connectors.serviceInsights && config.connectors.serviceInsights.enableServiceInsights !== 'disabled')
-    apis.push(require('./routes/serviceInsightsApi'));
+// prettier-ignore
+if (config.connectors.serviceInsights && config.connectors.serviceInsights.enableServiceInsights !== 'disabled') apis.push(require('./routes/serviceInsightsApi'));
 
 app.use('/api', ...apis);
 

--- a/src/components/serviceInsights/serviceInsights.jsx
+++ b/src/components/serviceInsights/serviceInsights.jsx
@@ -35,13 +35,10 @@ export default class ServiceInsights extends Component {
     };
 
     componentDidMount() {
-        if (this.hasValidSearchProps()) {
+        if (this.props.store.hasValidSearch) {
             this.getServiceInsight();
         }
     }
-
-    // Service Insights requires either a service to search for or a single trace
-    hasValidSearchProps = () => !!this.props.search.serviceName || !!this.props.search.traceId;
 
     // relationship to the central node is only applicable when a service is specified
     relationshipIsApplicable = () => !!this.props.search.serviceName;
@@ -90,7 +87,7 @@ export default class ServiceInsights extends Component {
 
         return (
             <section className="container serviceInsights">
-                {!this.hasValidSearchProps() && (
+                {!this.props.store.hasValidSearch && (
                     <p className="select-service-msg">
                         Please search for a serviceName in the global search bar to render a service insight (such as serviceName=example-service).
                     </p>
@@ -108,7 +105,7 @@ export default class ServiceInsights extends Component {
                     </div>
                 )}
 
-                {this.hasValidSearchProps() &&
+                {this.props.store.hasValidSearch &&
                     store.promiseState &&
                     store.promiseState.case({
                         pending: () => <Loading className="service-insights__loading" />,

--- a/src/components/universalSearch/tabs/tabStores/serviceInsightsTabStateStore.js
+++ b/src/components/universalSearch/tabs/tabStores/serviceInsightsTabStateStore.js
@@ -17,22 +17,24 @@
 
 import store from '../../../serviceInsights/stores/serviceInsightsStore';
 
-const subsystems = (window.haystackUiConfig && window.haystackUiConfig.subsystems) || [];
-const enableServiceInsights = (window.haystackUiConfig && window.haystackUiConfig.enableServiceInsights) || false;
-
 export class ServiceInsightsTabStateStore {
     search = null;
     isAvailable = false;
+    hasValidSearch = false;
 
     init(search) {
         this.search = search;
 
+        // is Service Insights enabled in the appliation config?
+        const enableServiceInsights = (window.haystackUiConfig && window.haystackUiConfig.enableServiceInsights) || false;
+
         // If user is directly accessing URL, show this feature
         const isAccessingServiceInsights = this.search.tabId === 'serviceInsights';
 
-        // TODO: reconcile this with hasValidSearchProps() in serviceInsights.jsx
-        const validSearchProps = search.serviceName || search.traceId;
-        this.isAvailable = isAccessingServiceInsights || !!(subsystems && enableServiceInsights && validSearchProps);
+        // has required minimal search terms
+        this.hasValidSearch = !!(search.serviceName || search.traceId);
+
+        this.isAvailable = enableServiceInsights && (this.hasValidSearch || isAccessingServiceInsights);
     }
 
     fetch() {

--- a/test/src/components/serviceInsights/serviceInsights.spec.jsx
+++ b/test/src/components/serviceInsights/serviceInsights.spec.jsx
@@ -29,6 +29,7 @@ function createStoreStub(promiseState, data = {}) {
     return {
         serviceInsights: data,
         fetchServiceInsights: sinon.stub(),
+        hasValidSearch: true,
         promiseState: {
             case: (resp) => resp[promiseState]()
         }
@@ -162,16 +163,6 @@ describe('<ServiceInsights/>', () => {
             const wrapper = shallow(<ServiceInsights search={search} store={store} />);
 
             expect(wrapper.find('Error')).to.have.length(1);
-        });
-
-        it('hasValidSearchProps() returns true or false if valid URL is found', () => {
-            const mockStore = {
-                fetchServiceInsights: sinon.spy()
-            };
-            const instance = shallow(<ServiceInsights search={{}} store={mockStore} history={{}} />).instance();
-            expect(instance.hasValidSearchProps()).to.equal(false);
-            const instance2 = shallow(<ServiceInsights search={{serviceName: 'mock-ui'}} store={mockStore} history={{}} />).instance();
-            expect(instance2.hasValidSearchProps()).to.equal(true);
         });
 
         it('handles select view filter', () => {

--- a/test/src/components/universalSearch/searchBar/stores/searchBarUiStateStore.spec.js
+++ b/test/src/components/universalSearch/searchBar/stores/searchBarUiStateStore.spec.js
@@ -50,6 +50,29 @@ describe('class SearchBarUiStateStore()', () => {
         expect(SearchBarUiStateStore.setOperatorFromValue([false])).to.equal('=');
     });
 
+    it('checkKeyForPeriods() finds key with periods', () => {
+        const result = SearchBarUiStateStore.checkKeyForPeriods('foo', {
+            'http.status.code': 'value'
+        });
+        expect(result).to.equal('foo.http.status.code');
+    });
+
+    it('checkValueForPeriods() finds value of key with period', () => {
+        const result = SearchBarUiStateStore.checkValueForPeriods({
+            '.': 'foo'
+        });
+        expect(result).to.equal('foo');
+    });
+
+    it('createChip() properly transforms data', () => {
+        const result = SearchBarUiStateStore.createChip('serviceName', 'foo');
+        expect(result).to.deep.equal({
+            key: 'serviceName',
+            operator: '=',
+            value: 'foo'
+        });
+    });
+
     it('properly processes chips', () => {
         const chips = [
             {
@@ -74,6 +97,59 @@ describe('class SearchBarUiStateStore()', () => {
             foo: 'bar',
             nested_foo: {
                 foo_sub: 'bar_sub'
+            }
+        });
+    });
+
+    it('getCurrentSearch() returns valid search object', () => {
+        const chips = [
+            {
+                key: 'foo',
+                operator: '=',
+                value: 'bar'
+            },
+            {
+                key: 'serviceName',
+                operator: '=',
+                value: 'mock-ui'
+            },
+            {
+                key: 'operationName',
+                operator: '=',
+                value: 'read'
+            }
+        ];
+        MockSearchBarUiStateStore = new SearchBarUiStateStore();
+        MockSearchBarUiStateStore.init({
+            tabId: 'serviceInsights',
+            time: {
+                from: 1,
+                to: 2
+            }
+        });
+        MockSearchBarUiStateStore.chips = chips;
+        const result = MockSearchBarUiStateStore.getCurrentSearch();
+        expect(result).to.deep.equal({
+            foo: 'bar',
+            tabId: 'serviceInsights',
+            operationName: 'read',
+            serviceName: 'mock-ui',
+            time: {
+                from: 1,
+                to: 2
+            }
+        });
+        MockSearchBarUiStateStore.setTimeWindow({
+            timePreset: 'Last Month'
+        });
+        const result2 = MockSearchBarUiStateStore.getCurrentSearch();
+        expect(result2).to.deep.equal({
+            foo: 'bar',
+            tabId: 'serviceInsights',
+            operationName: 'read',
+            serviceName: 'mock-ui',
+            time: {
+                preset: 'Last Month'
             }
         });
     });

--- a/test/src/components/universalSearch/tabs/tabStores/serviceInsightsTabStateStore.spec.js
+++ b/test/src/components/universalSearch/tabs/tabStores/serviceInsightsTabStateStore.spec.js
@@ -55,6 +55,34 @@ describe('class ServiceInsightsTabStateStore()', () => {
         });
         expect(store.isAvailable).to.equal(false);
     });
+
+    it('should set `isAvailable` as true if `tabId` is set to `serviceInsights` and feature is enabled', () => {
+        window.haystackUiConfig = {
+            enableServiceInsights: true
+        };
+        let store = require(modulePath).default; // eslint-disable-line
+        store.init({
+            tabId: 'serviceInsights'
+        });
+        expect(store.isAvailable).to.equal(true);
+    });
+
+    it('should set `isAvailable` as true if feature is enabled and has valid search', () => {
+        window.haystackUiConfig = {
+            enableServiceInsights: true
+        };
+        let store = require(modulePath).default; // eslint-disable-line
+        store.init({
+            traceId: '123456789'
+        });
+        expect(store.isAvailable).to.equal(true);
+
+        store.init({
+            serviceName: 'mock-ui'
+        });
+        expect(store.isAvailable).to.equal(true);
+    });
+
     it('should return a valid serviceInsights store from fetch()', () => {
         window.haystackUiConfig = {
             enableServiceInsights: true

--- a/test/src/components/universalSearch/tabs/tabStores/serviceInsightsTabStateStore.spec.js
+++ b/test/src/components/universalSearch/tabs/tabStores/serviceInsightsTabStateStore.spec.js
@@ -44,7 +44,7 @@ describe('class ServiceInsightsTabStateStore()', () => {
         });
         expect(store.isAvailable).to.equal(true);
     });
-    it('should set `isAvailable` as true if `tabId` is set to `serviceInsights`', () => {
+    it('should set `isAvailable` as false if `tabId` is set to `serviceInsights` and feature is disabled', () => {
         window.haystackUiConfig = {
             enableServiceInsights: false
         };
@@ -53,7 +53,7 @@ describe('class ServiceInsightsTabStateStore()', () => {
             tabId: 'serviceInsights',
             serviceName: 'mock-ui'
         });
-        expect(store.isAvailable).to.equal(true);
+        expect(store.isAvailable).to.equal(false);
     });
     it('should return a valid serviceInsights store from fetch()', () => {
         window.haystackUiConfig = {


### PR DESCRIPTION
# Overview

When initialization haystack-ui, if service insights configuration is not deployed, the feature causes the application to fail initialization.  We need to prevent initialization if service insights is not explicitly enabled in configuration.

Additionally, there is a minor code refactor simplification in service insights that does not change any behaviors.

Developed with @nathanwalther 