### PR TITLE
Fix bug in service insights

### DIFF
--- a/src/components/universalSearch/tabs/tabStores/serviceInsightsTabStateStore.js
+++ b/src/components/universalSearch/tabs/tabStores/serviceInsightsTabStateStore.js
@@ -38,6 +38,8 @@ export class ServiceInsightsTabStateStore {
     }
 
     fetch() {
+        // Copy `hasValidSearch` so serviceInsight reactJS component can leverage
+        store.hasValidSearch = this.hasValidSearch;
         return store;
     }
 }


### PR DESCRIPTION
# Overview

In `serviceInsights.jsx`, `store.isValidSearch` is a property that is required that determines whether or not the reactJS component will fetch service insights.  This property wasn't being copied from the tab store to the component store via the `fetch()` API.