### PR TITLE
remove tag duplicate filtering

### DIFF
--- a/src/components/traces/details/timeline/tagsTable.jsx
+++ b/src/components/traces/details/timeline/tagsTable.jsx
@@ -21,8 +21,7 @@ import blobUtil from '../../../../utils/blobUtil';
 import transform from '../../../../utils/tagValuesTransformer';
 
 const TagsTable = ({tags}) => {
-    const unique = _.uniqBy(tags, (tag) => tag.key.toLowerCase());
-    const sortedTags = _.sortBy(unique, [(tag) => tag.key.toLowerCase()]);
+    const sortedTags = _.sortBy(tags, [(tag) => tag.key.toLowerCase()]);
     const blobsUrl = window.haystackUiConfig && window.haystackUiConfig.blobsUrl;
 
     if (sortedTags.length) {


### PR DESCRIPTION
Filtering duplicate tags is not necessary, as it can lead to issues where a merged span has a different value in the client vs the server span